### PR TITLE
Change store.menu reference to "block"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Following is example how to replace main menu with user defined menu (with ident
 
 ```xml
 <referenceBlock name="catalog.topnav" remove="true"/>
-<referenceContainer name="store.menu">
+<referenceBlock name="store.menu">
   <block name="main.menu" class="Snowdog\Menu\Block\Menu" template="Snowdog_Menu::menu.phtml">
      <arguments>
         <argument name="menu" xsi:type="string">main</argument>
      </arguments>
   </block>
-</referenceContainer>
+</referenceBlock>
 ```
 
 ## Adding new types of nodes


### PR DESCRIPTION
The `store.menu` element [is a block](https://github.com/magento/magento2/blob/99e85cbc45223baa3551e4c534b650c0d2c6358b/app/code/Magento/Theme/view/frontend/layout/default.xml#L65), just tweaking the example to reflect that.