### PR TITLE
Fix true/false values for target checkbox

### DIFF
--- a/view/adminhtml/web/vue/menu-type/custom-url.vue
+++ b/view/adminhtml/web/vue/menu-type/custom-url.vue
@@ -19,8 +19,8 @@
                     class="checkbox"
                     type="checkbox"
                     id="snowmenu_custom_target"
-                    true-value="_blank"
-                    false-value="_self"
+                    true-value="1"
+                    false-value="0"
                     v-model="item.target"
                 />
             </div>


### PR DESCRIPTION
#44: Checking the target _blank option didn't save, because of the old true/false values used in the .vue file. 