### PR TITLE
WIP: Fixes #83: It is now possible to access category entity within category node template

### DIFF
--- a/Api/Data/NodeInterface.php
+++ b/Api/Data/NodeInterface.php
@@ -10,6 +10,7 @@ interface NodeInterface
     const MENU_ID = 'menu_id';
     const TYPE = 'type';
     const CONTENT = 'content';
+    const ENTITY = 'entity';
     const CLASSES = 'classes';
     const PARENT_ID = 'parent_id';
     const POSITION = 'position';

--- a/Model/NodeType/Category.php
+++ b/Model/NodeType/Category.php
@@ -97,16 +97,19 @@ class Category extends AbstractNode
 
         $localNodes = [];
         $categoryIds = [];
+        $categoryUrls = [];
+        $categories = [];
 
         foreach ($nodes as $node) {
             $localNodes[$node->getId()] = $node;
             $categoryIds[] = (int)$node->getContent();
         }
 
-        $categoryUrls = $this->getResource()->fetchData($storeId, $categoryIds);
+        /* @see \Snowdog\Menu\Model\ResourceModel\NodeType\Category->fetchData() */
+        $categories = $this->getResource()->fetchData($storeId, $categoryIds);
 
         $this->profiler->stop(__METHOD__);
 
-        return [$localNodes, $categoryUrls];
+        return [$localNodes, $categoryUrls, $categories];
     }
 }


### PR DESCRIPTION
Implements a new method `\Snowdog\Menu\Block\NodeType\Category::getCategory()` that
can be used to access the category entity within the block template.

Example usage:

```
/** @var \Snowdog\Menu\Block\NodeType\Category $block */
$imageSrc = $block->getCategory($nodeid)->getImageUrl();
```