### PR TITLE
Update NodeRepository.php

### DIFF
--- a/Model/Menu/NodeRepository.php
+++ b/Model/Menu/NodeRepository.php
@@ -12,6 +12,7 @@ use Snowdog\Menu\Api\Data\NodeInterface;
 use Snowdog\Menu\Api\NodeRepositoryInterface;
 use Snowdog\Menu\Model\Menu\NodeFactory;
 use Snowdog\Menu\Model\ResourceModel\Menu\Node\CollectionFactory;
+use Magento\Framework\Api\SortOrder;
 
 class NodeRepository implements NodeRepositoryInterface
 {


### PR DESCRIPTION
Added missing import for SortOrder on Line 91.

Corrects Class 'Snowdog\Menu\Model\Menu\SortOrder' not found

