### PR TITLE
Fixed array_filter() error if opening edit-menu-page from admin panel

### DIFF
--- a/Model/NodeType/CmsBlock.php
+++ b/Model/NodeType/CmsBlock.php
@@ -33,7 +33,7 @@ class CmsBlock extends AbstractNode
                 'label' => $block->getTitle(),
                 'value' => $block->getIdentifier(),
                 'store' => array_filter(
-                    $block->getStoreId(),
+                    (array)$block->getStoreId(),
                     function ($id) {
                         return (int)$id !== 0;
                     }

--- a/Model/NodeType/CmsPage.php
+++ b/Model/NodeType/CmsPage.php
@@ -33,7 +33,7 @@ class CmsPage extends AbstractNode
                 'label' => $page->getTitle(),
                 'value' => $page->getIdentifier(),
                 'store' => array_filter(
-                    $page->getStoreId(),
+                    (array)$page->getStoreId(),
                     function ($id) {
                         return (int)$id !== 0;
                     }


### PR DESCRIPTION
When you want to edit a menu containing a CMS block, the following exception appears:

```
1 exception(s):
Exception #0 (Exception): Warning: array_filter() expects parameter 1 to be array, null given in /Users/claudioferraro/Projects/loungeset-cssgrid/vendor/snowdog/module-menu/Model/NodeType/CmsBlock.php on line 39
```

Casting `$block->getStoreId()` to an array fixes the problem.