### PR TITLE
Move submenu template path to protected variable

### DIFF
--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -59,6 +59,11 @@ class Menu extends Template implements DataObject\IdentityInterface
      */
     protected $_template = 'Snowdog_Menu::menu.phtml';
 
+    /**
+     * @var string
+     */
+    protected $baseSubmenuTemplate = 'Snowdog_Menu::menu/sub_menu.phtml';
+
     public function __construct(
         Template\Context $context,
         EventManager $eventManager,
@@ -80,9 +85,7 @@ class Menu extends Template implements DataObject\IdentityInterface
         $this->eventManager = $eventManager;
         $this->templateResolver = $templateResolver;
         $this->escaper = $escaper;
-        $this->submenuTemplate = $this->getMenuTemplate(
-            'Snowdog_Menu::menu/sub_menu.phtml'
-        );
+        $this->submenuTemplate = $this->getMenuTemplate($this->baseSubmenuTemplate);
         $this->setTemplate($this->getMenuTemplate($this->_template));
     }
 


### PR DESCRIPTION
Recently i had to overwrite the constructor to change the submenu template and add a couple of private functions. This fix allows changing the submenu template without touching the constructor