### PR TITLE
Refactoring: Menu Repository

### DIFF
--- a/Api/MenuRepositoryInterface.php
+++ b/Api/MenuRepositoryInterface.php
@@ -1,14 +1,25 @@
 <?php
 namespace Snowdog\Menu\Api;
 
-use Snowdog\Menu\Api\Data\MenuInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Snowdog\Menu\Api\Data\MenuInterface;
 
 interface MenuRepositoryInterface
 {
     /**
+     * @param string $identifier
+     * @param int $storeId
+     * @return \Snowdog\Menu\Model\Menu
+     * @throws NoSuchEntityException
+     */
+    public function get($identifier, $storeId);
+
+    /**
      * @param \Snowdog\Menu\Api\Data\MenuInterface $page
      * @return \Snowdog\Menu\Api\Data\MenuInterface
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
     public function save(MenuInterface $page);
 
@@ -34,15 +45,12 @@ interface MenuRepositoryInterface
     public function delete(MenuInterface $page);
 
     /**
+     * Removes Menu with all nodes belonging to it
+     *
      * @param int $id
      * @return bool
+     * @throws CouldNotDeleteException
+     * @throws NoSuchEntityException
      */
     public function deleteById($id);
-
-    /**
-     * @param string $identifier
-     * @param int $storeId
-     * @return \Snowdog\Menu\Model\Menu
-     */
-    public function get($identifier, $storeId);
 }


### PR DESCRIPTION
1. `$model->save()` and `$model->delete()` breaks SOLID principle of single responsibility. Although it's not introduced to Coding Standard yet, the Resource Model should be used for operating with the database. https://github.com/magento/magento-coding-standard/issues/187
2. Add Exceptions to the interface, as these are part of interface API.
3. Improve verbosity and readability of the Repository (`Object` - > `Menu` etc.)