### PR TITLE
Feature: Validate only changed files, display errors inline

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,24 +1,40 @@
-name: Backend
-on: [push, pull_request_target]
+---
+name: Backend Coding Standard
+on: [ push, pull_request ]
 jobs:
   backend-lint:
     runs-on: ubuntu-latest
+    name: MCS Check
+    container:
+      image: docker.io/davidalger/php:7.4
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Add composer repositories
+          env:
+            USERNAME: ${{ secrets.COMPOSER_MAGENTO_USERNAME }}
+            PASSWORD: ${{ secrets.COMPOSER_MAGENTO_PASSWORD }}
+          run: composer config repositories.magento composer https://$USERNAME:$PASSWORD@repo.magento.com/
+      - name: Initialize config
+        id: config
+        run: |
+          echo "::set-output name=working-directory::${PWD/$GITHUB_WORKSPACE/}"
+          echo "::set-output name=composer-cache-dir::$(composer config cache-files-dir)"
+      - name: Retrieve composer cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.config.outputs.composer-cache-dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
-    - uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.4'
+      - run: composer global require hirak/prestissimo
+      - run: composer install --no-interaction --dev
 
-    - name: Add composer repositories
-      env:
-        USERNAME: ${{ secrets.COMPOSER_MAGENTO_USERNAME }}
-        PASSWORD: ${{ secrets.COMPOSER_MAGENTO_PASSWORD }}
-      run: composer config repositories.magento composer https://$USERNAME:$PASSWORD@repo.magento.com/
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
-
-    - name: Run tests
-      run: composer run-script test
+      - uses: mediotype/phpcs-action@v2
+        with:
+          enable_warnings: true     # This is required for magento-coding-standards to function
+          only_changed_files: true
+          phpcs_bin_path: ${{ github.workspace }}${{ steps.config.outputs.working-directory }}/vendor/bin/phpcs --standard=Magento2


### PR DESCRIPTION
I modified some PHP file introducing some issue that is reported by PHPCS.

Also:
1. Checkout only `depth = 1` to reduce the cost of pulling recent changes
2. Migrated your Composer configuration
3. Introduced Composer cache
4. Executing only on modified files