### PR TITLE
DEV-69078: replace default Magento title on index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Index page title (#69078)
+
 ## [2.12.0] - 2020-08-24
 ### Added
 - PHP 7.4 support (#118)

--- a/Controller/Adminhtml/Menu/Index.php
+++ b/Controller/Adminhtml/Menu/Index.php
@@ -15,6 +15,8 @@ class Index extends Action
      */
     public function execute()
     {
-        return $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+        $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+        $resultPage->getConfig()->getTitle()->prepend(__('Menus'));
+        return $resultPage;
     }
 }


### PR DESCRIPTION
Changed title from "Magento admin" to "Menus" on index page as requested in DEV-69078