### PR TITLE
Fixed v-if check on option.store array

### DIFF
--- a/view/adminhtml/web/vue/field-type/autocomplete.vue
+++ b/view/adminhtml/web/vue/field-type/autocomplete.vue
@@ -14,7 +14,7 @@
                 <template v-slot:option="option">
                     {{ option.label }}
 
-                    <template v-if="option.store">
+                    <template v-if="option.store.length > 0">
                         <span class="vs__dropdown-option__details">
                             {{ option.store.join(', ') }}
                         </span>


### PR DESCRIPTION
We've had this problem with some invalid pages. option.store is always an array, however, it might be empty.
With this merge request we explicitly check if there are any elements in the array.