### PR TITLE
IHB-279 fixed issue with flush cache after model is saved

### DIFF
--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -96,7 +96,7 @@ class Menu extends Template implements DataObject\IdentityInterface
      */
     public function getIdentities()
     {
-        return [\Snowdog\Menu\Model\Menu::CACHE_TAG . '_' . $this->loadMenu()->getId(), Block::CACHE_TAG];
+        return [\Snowdog\Menu\Model\Menu::CACHE_TAG . '_' . $this->loadMenu()->getId(), Block::CACHE_TAG, \Snowdog\Menu\Model\Menu::CACHE_TAG];
     }
 
     protected function getCacheLifetime()

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -96,7 +96,7 @@ class Menu extends Template implements DataObject\IdentityInterface
      */
     public function getIdentities()
     {
-        return [\Snowdog\Menu\Model\Menu::CACHE_TAG, Block::CACHE_TAG];
+        return [\Snowdog\Menu\Model\Menu::CACHE_TAG . '_' . $this->loadMenu()->getId(), Block::CACHE_TAG];
     }
 
     protected function getCacheLifetime()

--- a/Model/Menu.php
+++ b/Model/Menu.php
@@ -21,7 +21,7 @@ class Menu extends AbstractModel implements MenuInterface, IdentityInterface
 
     public function getIdentities()
     {
-        return [self::CACHE_TAG . '_' . $this->getId(), self::CACHE_TAG];
+        return [self::CACHE_TAG . '_' . $this->getId()];
     }
 
     public function getStores()

--- a/Model/Menu.php
+++ b/Model/Menu.php
@@ -21,7 +21,7 @@ class Menu extends AbstractModel implements MenuInterface, IdentityInterface
 
     public function getIdentities()
     {
-        return [self::CACHE_TAG . '_' . $this->getId()];
+        return [self::CACHE_TAG . '_' . $this->getId(), self::CACHE_TAG];
     }
 
     public function getStores()


### PR DESCRIPTION
This is fixing cache flushing after Menu model is saved. Currently when admin user hits 'Save' button in admin panel Abstract model tries to clear cache by tags, but tags for Model and Block are in not consistency.