### PR TITLE
Clarify documentation about adding a new node type

### DIFF
--- a/Block/Menu/Edit/Tab/Nodes.php
+++ b/Block/Menu/Edit/Tab/Nodes.php
@@ -9,34 +9,45 @@ use Magento\Framework\Registry;
 use Snowdog\Menu\Api\NodeRepositoryInterface;
 use Snowdog\Menu\Controller\Adminhtml\Menu\Edit;
 use Snowdog\Menu\Model\NodeTypeProvider;
+use Snowdog\Menu\Model\VueProvider;
 
 class Nodes extends Template implements TabInterface
 {
     protected $_template = 'menu/nodes.phtml';
+
     /**
      * @var Registry
      */
     private $registry;
+
     /**
      * @var NodeRepositoryInterface
      */
     private $nodeRepository;
+
     /**
      * @var NodeTypeProvider
      */
     private $nodeTypeProvider;
+
+    /**
+     * @var VueProvider
+     */
+    private $vueProvider;
 
     public function __construct(
         Template\Context $context,
         NodeRepositoryInterface $nodeRepository,
         NodeTypeProvider $nodeTypeProvider,
         Registry $registry,
+        VueProvider $vueProvider,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->registry = $registry;
         $this->nodeRepository = $nodeRepository;
         $this->nodeTypeProvider = $nodeTypeProvider;
+        $this->vueProvider = $vueProvider;
     }
 
     public function renderNodes()
@@ -142,5 +153,13 @@ class Nodes extends Template implements TabInterface
     public function getNodeLabels()
     {
         return $this->nodeTypeProvider->getLabels();
+    }
+
+    /**
+     * @return array
+     */
+    public function getVueComponents(): array
+    {
+        return $this->vueProvider->getComponents();
     }
 }

--- a/Model/VueProvider.php
+++ b/Model/VueProvider.php
@@ -9,15 +9,15 @@ class VueProvider
     /**
      * @var array
      */
-    private $providers;
+    private $components;
 
     /**
-     * @param array $providers
+     * @param array $components
      */
     public function __construct(
-        array $providers = []
+        array $components = []
     ) {
-        $this->providers = $providers;
+        $this->components = $components;
     }
 
     /**
@@ -26,8 +26,8 @@ class VueProvider
     public function getComponents(): array
     {
         $data = [];
-        foreach ($this->providers as $vueComponent) {
-            $data[] = sprintf('vue!Snowdog_Menu/vue/menu-type/%s', $vueComponent);
+        foreach ($this->components as $component) {
+            $data[] = sprintf('vue!Snowdog_Menu/vue/menu-type/%s', $component);
         }
 
         return $data;

--- a/Model/VueProvider.php
+++ b/Model/VueProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Model;
+
+class VueProvider
+{
+    /**
+     * @var array
+     */
+    private $providers;
+
+    /**
+     * @param array $providers
+     */
+    public function __construct(
+        array $providers = []
+    ) {
+        $this->providers = $providers;
+    }
+
+    /**
+     * @return array
+     */
+    public function getComponents(): array
+    {
+        $data = [];
+        foreach ($this->providers as $vueComponent) {
+            $data[] = sprintf('vue!Snowdog_Menu/vue/menu-type/%s', $vueComponent);
+        }
+
+        return $data;
+    }
+}

--- a/Model/VueProvider.php
+++ b/Model/VueProvider.php
@@ -6,6 +6,8 @@ namespace Snowdog\Menu\Model;
 
 class VueProvider
 {
+    const COMPONENT_PATH = 'vue!Snowdog_Menu/vue/menu-type/%s';
+
     /**
      * @var array
      */
@@ -27,7 +29,7 @@ class VueProvider
     {
         $data = [];
         foreach ($this->components as $component) {
-            $data[] = sprintf('vue!Snowdog_Menu/vue/menu-type/%s', $component);
+            $data[] = sprintf(self::COMPONENT_PATH, $component);
         }
 
         return $data;

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ UI initialization starts in `view/adminhtml/templates/menu/nodes.phtml` where we
 $vueComponents = $block->getVueComponents();
 ```
 
-```javascript
+```js
 <script type="text/x-magento-init">
     {
         "*": {
@@ -90,7 +90,7 @@ Then in `view/adminhtml/web/vue/menu-type/` we add `component-file-name.vue` ex.
 
 In new vue file we register our component (`component_name` ex. `cms_block`) and we add our logic we need. 
 
-```javascript
+```vue
 <template>
     ...
 </template>
@@ -142,7 +142,7 @@ When saving menu changes we send form post request that contains several fields 
 >
 ```
 
-```javascript
+```js
 computed: {
     jsonList: function() {
         return JSON.stringify(this.list);
@@ -150,15 +150,14 @@ computed: {
 }
 ```
 
-Currently `list, item` objects are passed from `App.vue` to child components.
-As they are objects,  they are passed by reference so editing it updates also value
-of `serialized_nodes`
+The `list` and `item` objects are passed from `App.vue` to child components.
+As they are objects,  they are passed by reference, so editing it in child components, updates the value of `serialized_nodes` in `App.vue`.
 
-This is not an ideal way, and we plan to refactor it in the future version of the module.
+This is not an ideal way of mutating data, and we plan to refactor it.
 
-For now look at `menu-type.vue` where you can find
+For now look at `menu-type.vue` you can find
 
-```
+```vue
 <component
     :is="item['type']"
     :item="item"
@@ -168,13 +167,7 @@ For now look at `menu-type.vue` where you can find
 
 This loads dynamically a component of a chosen type of node. For example for a node type: `cms_block` -> `cms-block.vue` 
 
-Cms block component uses `autocomplete.vue` component with prop item `:item="item"`.
-When you look at `autocomplete.vue` you can see that any changes that should be saved in a database are assigned to proper property of item object.  
-
-```javascript
-this.item.content = option.value.toString();
-```
-
+Cms block node type component uses `autocomplete.vue` input type component with prop item `:item="item"`, once user made some change, the data are propagated up to the root, `App.vue` compoonent and saved, stringifies and saved in a hidden input. 
 
 ## Available endpoints: 
    

--- a/README.md
+++ b/README.md
@@ -48,15 +48,12 @@ Menu UI in admin panel is build with Vue.js.
 Every node type has its own vue component located inside `view/adminhtml/web/vue/menu-type` directory.
 (See `view/adminhtml/web/vue/menu-type/category.vue` or `view/adminhtml/web/vue/menu-type/cms-block.vue` examples for a reference)
 
-UI initialization starts in `view/adminhtml/templates/menu/nodes.phtml` where we
-initialize `menu.js` and we pass list of paths of vue components that are assigned to each node type using
-`"vueComponents"` property (see two fragments of code from `nodes.phtml` below).
+UI initialization starts in `view/adminhtml/templates/menu/nodes.phtml` where we initialize `menu.js` and we pass list of paths of Vue components that are assigned to each node type using `"vueComponents"` property (see two fragments of code from `nodes.phtml` below).
 
 ```php
-// ...
 $vueComponents = $block->getVueComponents();
-/// ...
 ```
+
 ```javascript
 <script type="text/x-magento-init">
     {
@@ -70,7 +67,7 @@ $vueComponents = $block->getVueComponents();
 </script>
 ```
 
-So to show new node in UI we need to add new vue component via `di.xml`
+To show new node in UI we need to add new Vue component via `di.xml`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -91,8 +88,7 @@ Where we need to define
 
 Then in `view/adminhtml/web/vue/menu-type/` we add `component-file-name.vue` ex. `cms-block.vue`
 
-In new vue file we register our component (`component_name` ex. `cms_block`) and
-we add our logic we need. 
+In new vue file we register our component (`component_name` ex. `cms_block`) and we add our logic we need. 
 
 ```javascript
 <template>

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ Backend block will be directly injected into menu editor.
 Menu editor is using Vue.js so you need to create a new vue component that has node type code as name in `view/adminhtml/web/vue/menu-type` and load it in `view/adminhtml/templates/menu/nodes.phtml`
 (See `view/adminhtml/web/vue/menu-type/category.vue` for reference)
 
+Add new vue component via `di.xml`
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Snowdog\Menu\Model\VueProvider">
+        <arguments>
+            <argument name="components" xsi:type="array">
+                <item name="component_name" xsi:type="string">component_name</item>
+            </argument>
+        </arguments>
+    </type>
+</config>
+```
+
 Newly created block with additional method should be added via `di.xml` defining block instance and node type code (code will be stored in database).
 
 ```xml

--- a/README.md
+++ b/README.md
@@ -36,13 +36,41 @@ Snowdog_Menu
 ```
 
 ## Adding new types of nodes
-To add new type node you have to add new backend block that also implements `\Snowdog\Menu\Api\NodeTypeInterface`.
+To add new type node you have to add:
+ - new backend block that also implements `\Snowdog\Menu\Api\NodeTypeInterface` and is defined in di.xml
+ - create new vue component for new type node and define it in di.xml
 
 Backend block will be directly injected into menu editor.
-Menu editor is using Vue.js so you need to create a new vue component that has node type code as name in `view/adminhtml/web/vue/menu-type` and load it in `view/adminhtml/templates/menu/nodes.phtml`
-(See `view/adminhtml/web/vue/menu-type/category.vue` for reference)
 
-Add new vue component via `di.xml`
+### New node type in admin panel
+Menu UI in admin panel is build with Vue.js.
+
+Every node type has its own vue component located inside `view/adminhtml/web/vue/menu-type` directory.
+(See `view/adminhtml/web/vue/menu-type/category.vue` or `view/adminhtml/web/vue/menu-type/cms-block.vue` examples for a reference)
+
+UI initialization starts in `view/adminhtml/templates/menu/nodes.phtml` where we
+initialize `menu.js` and we pass list of paths of vue components that are assigned to each node type using
+`"vueComponents"` property (see two fragments of code from `nodes.phtml` below).
+
+```php
+// ...
+$vueComponents = $block->getVueComponents();
+/// ...
+```
+```javascript
+<script type="text/x-magento-init">
+    {
+        "*": {
+            "menuNodes": {
+                "vueComponents": <?= json_encode($vueComponents) ?>,
+                // ...
+            }
+        }
+    }
+</script>
+```
+
+So to show new node in UI we need to add new vue component via `di.xml`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -50,11 +78,34 @@ Add new vue component via `di.xml`
     <type name="Snowdog\Menu\Model\VueProvider">
         <arguments>
             <argument name="components" xsi:type="array">
-                <item name="component_name" xsi:type="string">component_name</item>
+                <item name="component_name" xsi:type="string">component-file-name</item>
             </argument>
         </arguments>
     </type>
 </config>
+```
+
+Where we need to define
+- `component_name` - example: `cms_block`
+- `component-file-name` -  example: `cms-block`
+
+Then in `view/adminhtml/web/vue/menu-type/` we add `component-file-name.vue` ex. `cms-block.vue`
+
+In new vue file we register our component (`component_name` ex. `cms_block`) and
+we add our logic we need. 
+
+```javascript
+<template>
+    ...
+</template>
+<script>
+    define(['Vue'], function(Vue) {
+        Vue.component('component_name', {
+        // example: Vue.component('cms_block', {
+            ...
+        }
+    })
+</script>
 ```
 
 Newly created block with additional method should be added via `di.xml` defining block instance and node type code (code will be stored in database).
@@ -71,6 +122,63 @@ Newly created block with additional method should be added via `di.xml` defining
     </type>
 </config>
 ```
+
+`my_node_type` - example: `cms_block` (the same as `component_name`)
+`Foo\Bar\Block\NodeType\MyNode` - example: `Snowdog\Menu\Block\NodeType\CmsBlock`
+
+In our `cms_block` example it would be:
+```xml
+<item name="cms_block" xsi:type="object">Snowdog\Menu\Block\NodeType\CmsBlock</item>
+```
+
+### How to save data from vue components when saving menu changes?
+When saving menu changes we send form post request that contains several fields like:
+`form_key, id, title, identifier, css_class, stores[], serialized_notes`. 
+
+`serialized_notes` stores data from our vue components using computed property `jsonList`.
+
+**App.vue:**
+```html
+<input
+    type="hidden"
+    name="serialized_nodes"
+    :value="jsonList"
+>
+```
+
+```javascript
+computed: {
+    jsonList: function() {
+        return JSON.stringify(this.list);
+    }
+}
+```
+
+Currently `list, item` objects are passed from `App.vue` to child components.
+As they are objects,  they are passed by reference so editing it updates also value
+of `serialized_nodes`
+
+This is not an ideal way, and we plan to refactor it in the future version of the module.
+
+For now look at `menu-type.vue` where you can find
+
+```
+<component
+    :is="item['type']"
+    :item="item"
+    :config="config"
+/>
+```
+
+This loads dynamically a component of a chosen type of node. For example for a node type: `cms_block` -> `cms-block.vue` 
+
+Cms block component uses `autocomplete.vue` component with prop item `:item="item"`.
+When you look at `autocomplete.vue` you can see that any changes that should be saved in a database are assigned to proper property of item object.  
+
+```javascript
+this.item.content = option.value.toString();
+```
+
 
 ## Available endpoints: 
    

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Snowdog\Menu\Api\MenuRepositoryInterface" type="Snowdog\Menu\Model\MenuRepository"/>
     <preference for="Snowdog\Menu\Api\NodeRepositoryInterface" type="Snowdog\Menu\Model\Menu\NodeRepository"/>
     <preference for="Snowdog\Menu\Api\Data\MenuSearchResultsInterface" type="Magento\Framework\Api\SearchResults"/>
@@ -16,6 +17,18 @@
                 <item name="custom_url" xsi:type="object">Snowdog\Menu\Block\NodeType\CustomUrl</item>
                 <item name="category_child" xsi:type="object">Snowdog\Menu\Block\NodeType\CategoryChild</item>
                 <item name="wrapper" xsi:type="object">Snowdog\Menu\Block\NodeType\Wrapper</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Snowdog\Menu\Model\VueProvider">
+        <arguments>
+            <argument name="providers" xsi:type="array">
+                <item name="category" xsi:type="string">category</item>
+                <item name="product" xsi:type="string">product</item>
+                <item name="cms_page" xsi:type="string">cms-page</item>
+                <item name="cms_block" xsi:type="string">cms-block</item>
+                <item name="custom_url" xsi:type="string">custom-url</item>
+                <item name="wrapper" xsi:type="string">wrapper</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -22,7 +22,7 @@
     </type>
     <type name="Snowdog\Menu\Model\VueProvider">
         <arguments>
-            <argument name="providers" xsi:type="array">
+            <argument name="components" xsi:type="array">
                 <item name="category" xsi:type="string">category</item>
                 <item name="product" xsi:type="string">product</item>
                 <item name="cms_page" xsi:type="string">cms-page</item>

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -1,5 +1,6 @@
 var config = {
     paths: {
+        'menuNodes': 'Snowdog_Menu/js/nodes',
         'Vue': 'Snowdog_Menu/js/lib/vue',
         'vue': 'Snowdog_Menu/js/lib/require-vuejs',
         'Vddl': 'Snowdog_Menu/js/lib/vddl',

--- a/view/adminhtml/templates/menu/nodes.phtml
+++ b/view/adminhtml/templates/menu/nodes.phtml
@@ -1,21 +1,12 @@
 <?php
-/** @var \Snowdog\Menu\Block\NodeType\AbstractNode $form */
+/** @var \Snowdog\Menu\Block\Menu\Edit\Tab\Nodes $block */
+
 $fieldData = [];
+/** @var \Snowdog\Menu\Block\NodeType\AbstractNode $form */
 foreach ($block->getNodeForms() as $form) {
     $fieldData[$form->getNodeType()] = $form->getJsonConfig();
 }
-
-// TODO: backend - create method to return array of nodes components
-// https://github.com/SnowdogApps/magento2-menu/issues/69#issuecomment-443500749
-$vueComponents = [
-    "vue!Snowdog_Menu/vue/menu-type/category",
-    "vue!Snowdog_Menu/vue/menu-type/cms-page",
-    "vue!Snowdog_Menu/vue/menu-type/cms-block",
-    "vue!Snowdog_Menu/vue/menu-type/custom-url",
-    "vue!Snowdog_Menu/vue/menu-type/product",
-    "vue!Snowdog_Menu/vue/menu-type/wrapper",
-];
-
+$vueComponents = $block->getVueComponents();
 ?>
 
 <div id="snowdog_menu">

--- a/view/adminhtml/templates/menu/nodes.phtml
+++ b/view/adminhtml/templates/menu/nodes.phtml
@@ -23,61 +23,43 @@ foreach ($block->getNodeForms() as $form) {
     </snowdog-menu>
 </div>
 
-<script>
-    require(
-        [
-            "Vue",
-            "Vddl",
-            "vue-select",
-            "vue!Snowdog_Menu/vue/app",
-            "vue!Snowdog_Menu/vue/nested-list",
-            "vue!Snowdog_Menu/vue/menu-type",
-            "vue!Snowdog_Menu/vue/menu-type/category",
-            "vue!Snowdog_Menu/vue/menu-type/cms-page",
-            "vue!Snowdog_Menu/vue/menu-type/cms-block",
-            "vue!Snowdog_Menu/vue/menu-type/custom-url",
-            "vue!Snowdog_Menu/vue/menu-type/product",
-            "vue!Snowdog_Menu/vue/menu-type/wrapper",
-            "vue!Snowdog_Menu/vue/field-type/simple",
-            "vue!Snowdog_Menu/vue/field-type/checkbox",
-            "vue!Snowdog_Menu/vue/field-type/autocomplete"
-        ], function(Vue, Vddl, vueSelect) {
-            Vue.use(Vddl);
-            Vue.component('v-select', vueSelect.VueSelect);
-            var app = new Vue({
-                el  : "#snowdog_menu",
-                data: {
-                    list  : <?= json_encode($block->renderNodes()) ?>,
-                    config: {
-                        fieldData  : <?= json_encode($fieldData) ?>,
-                        nodeTypes  : <?= json_encode($block->getNodeLabels()) ?>,
-                        translation: {
-                            nodes          : "<?= __('Nodes') ?>",
-                            click          : "<?= __('Click') ?>",
-                            createFirstNode: "<?= __('to create your first node.') ?>",
-                            createSubNode  : "<?= __('to create sub node or drag and drop other nodes here.') ?>",
-                            append         : "<?= __('Append') ?>",
-                            edit           : "<?= __('Edit') ?>",
-                            delete         : "<?= __('Delete') ?>",
-                            addNode        : "<?= __('New node') ?>",
-                            nodeType       : "<?= __('Node Type') ?>",
-                            nodeName       : "<?= __('Node name') ?>",
-                            nodeClasses    : "<?= __('Node CSS classes') ?>",
-                            selectNodeType : "<?= __('Select Node Type') ?>",
-                            pleaseSelect   : "<?= __('Please select a') ?>",
-                            targetLabel    : "<?= __('Node target blank') ?>",
-                            category       : "<?= __('Category') ?>",
-                            categoryId     : "<?= __('Category ID') ?>",
-                            block          : "<?= __('Block') ?>",
-                            blockId        : "<?= __('Block ID') ?>",
-                            page           : "<?= __('Page') ?>",
-                            pageId         : "<?= __('Page URL key') ?>",
-                            customURL      : "<?= __('Custom URL') ?>",
-                            product        : "<?= __('Product') ?>",
-                            productId      : "<?= __('Product ID') ?>"
+<script type="text/x-magento-init">
+    {
+        "*": {
+            "menuNodes": {
+                "data": {
+                    "list"  : <?= json_encode($block->renderNodes()) ?>,
+                    "config": {
+                        "fieldData"  : <?= json_encode($fieldData) ?>,
+                        "nodeTypes"  : <?= json_encode($block->getNodeLabels()) ?>,
+                        "translation": {
+                            "nodes"          : "<?= __('Nodes') ?>",
+                            "click"          : "<?= __('Click') ?>",
+                            "createFirstNode": "<?= __('to create your first node.') ?>",
+                            "createSubNode"  : "<?= __('to create sub node or drag and drop other nodes here.') ?>",
+                            "append"         : "<?= __('Append') ?>",
+                            "edit"           : "<?= __('Edit') ?>",
+                            "delete"         : "<?= __('Delete') ?>",
+                            "addNode"        : "<?= __('New node') ?>",
+                            "nodeType"       : "<?= __('Node Type') ?>",
+                            "nodeName"       : "<?= __('Node name') ?>",
+                            "nodeClasses"    : "<?= __('Node CSS classes') ?>",
+                            "selectNodeType" : "<?= __('Select Node Type') ?>",
+                            "pleaseSelect"   : "<?= __('Please select a') ?>",
+                            "targetLabel"    : "<?= __('Node target blank') ?>",
+                            "category"       : "<?= __('Category') ?>",
+                            "categoryId"     : "<?= __('Category ID') ?>",
+                            "block"          : "<?= __('Block') ?>",
+                            "blockId"        : "<?= __('Block ID') ?>",
+                            "page"           : "<?= __('Page') ?>",
+                            "pageId"         : "<?= __('Page URL key') ?>",
+                            "customURL"      : "<?= __('Custom URL') ?>",
+                            "product"        : "<?= __('Product') ?>",
+                            "productId"      : "<?= __('Product ID') ?>"
                         }
                     }
                 }
-            });
-        });
+            }
+        }
+    }
 </script>

--- a/view/adminhtml/templates/menu/nodes.phtml
+++ b/view/adminhtml/templates/menu/nodes.phtml
@@ -4,6 +4,18 @@ $fieldData = [];
 foreach ($block->getNodeForms() as $form) {
     $fieldData[$form->getNodeType()] = $form->getJsonConfig();
 }
+
+// TODO: backend - create method to return array of nodes components
+// https://github.com/SnowdogApps/magento2-menu/issues/69#issuecomment-443500749
+$vueComponents = [
+    "vue!Snowdog_Menu/vue/menu-type/category",
+    "vue!Snowdog_Menu/vue/menu-type/cms-page",
+    "vue!Snowdog_Menu/vue/menu-type/cms-block",
+    "vue!Snowdog_Menu/vue/menu-type/custom-url",
+    "vue!Snowdog_Menu/vue/menu-type/product",
+    "vue!Snowdog_Menu/vue/menu-type/wrapper",
+];
+
 ?>
 
 <div id="snowdog_menu">
@@ -27,6 +39,7 @@ foreach ($block->getNodeForms() as $form) {
     {
         "*": {
             "menuNodes": {
+                "vueComponents": <?= json_encode($vueComponents) ?>,
                 "data": {
                     "list"  : <?= json_encode($block->renderNodes()) ?>,
                     "config": {

--- a/view/adminhtml/web/js/nodes.js
+++ b/view/adminhtml/web/js/nodes.js
@@ -5,22 +5,26 @@ define([
     "vue!Snowdog_Menu/vue/app",
     "vue!Snowdog_Menu/vue/nested-list",
     "vue!Snowdog_Menu/vue/menu-type",
-    "vue!Snowdog_Menu/vue/menu-type/category",
-    "vue!Snowdog_Menu/vue/menu-type/cms-page",
-    "vue!Snowdog_Menu/vue/menu-type/cms-block",
-    "vue!Snowdog_Menu/vue/menu-type/custom-url",
-    "vue!Snowdog_Menu/vue/menu-type/product",
-    "vue!Snowdog_Menu/vue/menu-type/wrapper",
     "vue!Snowdog_Menu/vue/field-type/simple",
     "vue!Snowdog_Menu/vue/field-type/checkbox",
     "vue!Snowdog_Menu/vue/field-type/autocomplete"
 ], function(Vue, Vddl, vueSelect) {
+
     return function(config) {
-        Vue.use(Vddl);
-        Vue.component('v-select', vueSelect.VueSelect);
-        var app = new Vue({
-            el  : config.el || "#snowdog_menu",
-            data: config.data
+        var dependencies = [];
+
+        if (config.vueComponents && config.vueComponents.length > 0) {
+            dependencies = config.vueComponents;
+        }
+
+        require(dependencies, function() {
+            Vue.use(Vddl);
+
+            Vue.component('v-select', vueSelect.VueSelect);
+            var app = new Vue({
+                el  : config.el || "#snowdog_menu",
+                data: config.data
+            });
         });
     }
 });

--- a/view/adminhtml/web/js/nodes.js
+++ b/view/adminhtml/web/js/nodes.js
@@ -1,0 +1,26 @@
+define([
+    "Vue",
+    "Vddl",
+    "vue-select",
+    "vue!Snowdog_Menu/vue/app",
+    "vue!Snowdog_Menu/vue/nested-list",
+    "vue!Snowdog_Menu/vue/menu-type",
+    "vue!Snowdog_Menu/vue/menu-type/category",
+    "vue!Snowdog_Menu/vue/menu-type/cms-page",
+    "vue!Snowdog_Menu/vue/menu-type/cms-block",
+    "vue!Snowdog_Menu/vue/menu-type/custom-url",
+    "vue!Snowdog_Menu/vue/menu-type/product",
+    "vue!Snowdog_Menu/vue/menu-type/wrapper",
+    "vue!Snowdog_Menu/vue/field-type/simple",
+    "vue!Snowdog_Menu/vue/field-type/checkbox",
+    "vue!Snowdog_Menu/vue/field-type/autocomplete"
+], function(Vue, Vddl, vueSelect) {
+    return function(config) {
+        Vue.use(Vddl);
+        Vue.component('v-select', vueSelect.VueSelect);
+        var app = new Vue({
+            el  : config.el || "#snowdog_menu",
+            data: config.data
+        });
+    }
+});

--- a/view/adminhtml/web/vue/menu-type.vue
+++ b/view/adminhtml/web/vue/menu-type.vue
@@ -37,7 +37,7 @@
             id="node_name"
             v-model="item.title"
             :label="config.translation.nodeName"
-            type="textarea"
+            type="text"
         />
 
         <simple-field


### PR DESCRIPTION
Related to #69 

First commit is quite clear - moving code to external file to improve extendability via js mixins if someone would need to add/change something here

Second commit - possible way of loading additional components for new node types. We just need backend dev to return array in nodes.phtml (as suggested by @Koc)