### PR TITLE
[77605] Changes Product Node Price Data from final_price to min_price

### DIFF
--- a/Model/ResourceModel/NodeType/Product.php
+++ b/Model/ResourceModel/NodeType/Product.php
@@ -62,7 +62,7 @@ class Product extends AbstractNode
         $table = $this->getTable('catalog_product_index_price');
         $select = $connection
             ->select()
-            ->from($table, ['entity_id', 'final_price'])
+            ->from($table, ['entity_id', 'min_price'])
             ->where('customer_group_id = ?', $customerGroupId)
             ->where('website_id = ?', $websiteId)
             ->where('entity_id IN (?)', $productIds);


### PR DESCRIPTION
Gets min_price data from DB rather than final_price data, which caused an issue where the price would return 0 on configurable products, I have tested this with simple products, and all works as expected.