### PR TITLE
Implement product object

### DIFF
--- a/Block/NodeType/Product.php
+++ b/Block/NodeType/Product.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Snowdog\Menu\Block\NodeType;
 
+use Magento\Catalog\Model\ProductRepository;
 use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
 use Snowdog\Menu\Model\TemplateResolver;
@@ -56,6 +57,11 @@ class Product extends AbstractNode
     protected $productTitles;
 
     /**
+     * @var ProductRepository
+     */
+    protected $productRepository;
+
+    /**
      * @var Registry
      */
     private $coreRegistry;
@@ -87,6 +93,7 @@ class Product extends AbstractNode
         TemplateResolver $templateResolver,
         PricingHelper $priceHelper,
         ImageHelper $imageHelper,
+        ProductRepository $productRepository,
         array $data = []
     ) {
         parent::__construct($context, $templateResolver, $data);
@@ -94,6 +101,7 @@ class Product extends AbstractNode
         $this->productModel = $productModel;
         $this->priceHelper = $priceHelper;
         $this->imageHelper = $imageHelper;
+        $this->productRepository = $productRepository;
     }
 
     /**
@@ -102,6 +110,23 @@ class Product extends AbstractNode
     public function getCurrentProduct()
     {
         return $this->coreRegistry->registry('current_product');
+    }
+
+    /**
+     * @param int $nodeId
+     * @return ProductRepository
+     * @throws \InvalidArgumentException
+     */
+    public function getProductById($nodeId)
+    {
+        if (!isset($this->nodes[$nodeId])) {
+            throw new \InvalidArgumentException('Invalid node identifier specified');
+        }
+
+        $node = $this->nodes[$nodeId];
+        $productId = (int)$node->getContent();
+
+        return $this->productRepository->getById($productId);
     }
 
     /**

--- a/view/frontend/templates/menu/node_type/product.phtml
+++ b/view/frontend/templates/menu/node_type/product.phtml
@@ -2,6 +2,7 @@
 <?php
 $nodeId = $block->getId();
 $class = $block->getMenuClass();
+$product = $block->getProductById($nodeId);
 $productUrl = $block->getProductUrl($nodeId);
 $productPrice = $block->getProductPrice($nodeId);
 $formattedProductPrice = $block->getFormattedProductPrice($nodeId);


### PR DESCRIPTION
The function getCurrentProduct() doesn't work.

https://github.com/SnowdogApps/magento2-menu/blob/d5532c14fc7516791d101991342f52640d63d6dd/Block/NodeType/Product.php#L99-L105

Maybe because the Magento\Framework\Registry is deprecated, however, I added a simple workaround to be able to get the product object in the product.phtml template.