### PR TITLE
Fix get product title method

### DIFF
--- a/Model/ResourceModel/NodeType/Product.php
+++ b/Model/ResourceModel/NodeType/Product.php
@@ -106,7 +106,7 @@ class Product extends AbstractNode
     public function fetchTitleData($storeId = Store::DEFAULT_STORE_ID, $productIds = [])
     {
         $collection = $this->productCollection->create();
-        $collection->addAttributeToSelect(['name'])
+        $collection->addAttributeToSelect(['name', 'left'])
             ->addFieldToFilter('entity_id', ['in' => $productIds])
             ->addStoreFilter($storeId);
 


### PR DESCRIPTION
Magento 2.4.5-p1, the method fetchTitleData is returning an array with empty values.
https://github.com/SnowdogApps/magento2-menu/blob/d5532c14fc7516791d101991342f52640d63d6dd/Model/ResourceModel/NodeType/Product.php#L106-L120

It was missing the join type like in the method fetchImageData
https://github.com/SnowdogApps/magento2-menu/blob/d5532c14fc7516791d101991342f52640d63d6dd/Model/ResourceModel/NodeType/Product.php#L81