### PR TITLE
Remove image fields from Category Child and CMS block nodes

### DIFF
--- a/view/adminhtml/web/vue/menu-type.vue
+++ b/view/adminhtml/web/vue/menu-type.vue
@@ -144,8 +144,7 @@
                     return this.templateOptionsData[this.item['type']] || [];
                 },
                 showImage: function() {
-                    return this.item.type !== 'cms_page'
-                        && this.item.type !== 'wrapper';
+                    return ['category', 'product', 'custom_url'].includes(this.item.type);
                 }
             },
             methods: {


### PR DESCRIPTION
Category Child and CMS block nodes don’t display uploaded images, although they have those fields enabled. If uploaded pictures can't be displayed in those nodes, it shouldn't be possible to upload it.

On the edit menu page that's visible on the frontend:
1. Create a Category Child node.
2. Add an image to the Category Child node (Women).
3. Create a CMS block node.
4. Add an image to the CMS block node (Footer links block).
5. Save the menu and go to the frontend.

Expected: When hovering over the two nodes, the uploaded pictures are displayed inside them.
Actual: The images are not displayed inside the nodes.