### PR TITLE
Feature/102193

### DIFF
--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -432,7 +432,7 @@ class Menu extends Template implements DataObject\IdentityInterface
         $block = clone $this;
         $submenuTemplate = $parentNode->getSubmenuTemplate();
         $submenuTemplate = $submenuTemplate
-            ? 'Snowdog_Menu::' . $this->getMenu()->getIdentifier() . "/menu/custom/sub_menu/{$submenuTemplate}.phtml"
+            ? 'Snowdog_Menu::' . $this->getMenuTemplateDir() . "/menu/custom/sub_menu/{$submenuTemplate}.phtml"
             : $this->submenuTemplate;
 
         $block->setSubmenuNodes($nodes)

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -128,6 +128,15 @@ class Menu extends Template implements DataObject\IdentityInterface
         ];
     }
 
+    private function getMenuTemplateDir(): string
+    {
+        if (!$this->getData('menu_template_dir')) {
+            return $this->getData('menu');
+        }
+
+        return $this->getData('menu_template_dir');
+    }
+
     protected function getCacheLifetime()
     {
         return 60*60*24*365;
@@ -400,6 +409,7 @@ class Menu extends Template implements DataObject\IdentityInterface
             ->setNodeClasses($node->getClasses())
             ->setMenuClass($this->getMenu()->getCssClass())
             ->setMenuCode($this->getData('menu'))
+            ->setMenuTemplateDir($this->getMenuTemplateDir())
             ->setTarget($node->getTarget())
             ->setImage($node->getImage())
             ->setImageUrl($node->getImage() ? $this->imageFile->getUrl($node->getImage()) : null)
@@ -481,7 +491,7 @@ class Menu extends Template implements DataObject\IdentityInterface
     {
         return $this->templateResolver->getMenuTemplate(
             $this,
-            $this->getData('menu'),
+            $this->getMenuTemplateDir(),
             $template
         );
     }

--- a/Block/NodeType/AbstractNode.php
+++ b/Block/NodeType/AbstractNode.php
@@ -157,7 +157,7 @@ abstract class AbstractNode extends Template implements NodeTypeInterface
     {
         $template = $this->templateResolver->getMenuTemplate(
             $this,
-            $this->getMenuCode(),
+            $this->getMenuTemplateDir(),
             $this->defaultTemplate,
             $this->getId()
         );

--- a/Model/TemplateResolver.php
+++ b/Model/TemplateResolver.php
@@ -83,36 +83,36 @@ class TemplateResolver
 
     /**
      * @param Template $block
-     * @param string $menuId
+     * @param string $menuTemplateDir
      * @param string $template
      * @param int|null $nodeId
      * @return string
      */
-    public function getMenuTemplate($block, $menuId, $template, $nodeId = null)
+    public function getMenuTemplate($block, $menuTemplateDir, $template, $nodeId = null)
     {
-        $mapId = $menuId . '-' . ($nodeId ? $nodeId . '-' : '') . $template;
+        $mapId = $menuTemplateDir . '-' . ($nodeId ? $nodeId . '-' : '') . $template;
         if (isset($this->templateMap[$mapId])) {
             return $this->templateMap[$mapId];
         }
 
         $templateArr = explode('::', $template);
         if ($block->getCustomTemplate()) {
-            $newTemplate = $menuId
+            $newTemplate = $menuTemplateDir
                 . DIRECTORY_SEPARATOR
                 . $block->getCustomTemplateFolder()
                 . $block->getCustomTemplate()
                 . '.phtml';
         } elseif (isset($templateArr[1])) {
-            $newTemplate = $templateArr[0] . '::' . $menuId . DIRECTORY_SEPARATOR . $templateArr[1];
+            $newTemplate = $templateArr[0] . '::' . $menuTemplateDir . DIRECTORY_SEPARATOR . $templateArr[1];
         } else {
-            $newTemplate = $menuId . DIRECTORY_SEPARATOR . $template;
+            $newTemplate = $menuTemplateDir . DIRECTORY_SEPARATOR . $template;
         }
 
         if (!$this->validator->isValid($block->getTemplateFile($newTemplate))) {
-            return $this->setTemplateMap($menuId, $template, $template, $nodeId);
+            return $this->setTemplateMap($menuTemplateDir, $template, $template, $nodeId);
         }
 
-        return $this->setTemplateMap($menuId, $newTemplate, $template, $nodeId);
+        return $this->setTemplateMap($menuTemplateDir, $newTemplate, $template, $nodeId);
     }
 
     /**


### PR DESCRIPTION
This feature allows you to use the same custom template for several menus. To do this, when declaring the menu in the xml file, add the parameter "menu_template_dir" It should look like this:


```
<block name="menu-1" class="Snowdog\Menu\Block\Menu">
                <arguments>
                    <argument name="menu" xsi:type="string">menu-1</argument>
                    <argument name="menu_template_dir" xsi:type="string">custom-menu</argument>
                </arguments>
</block>
```