### PR TITLE
fix: missing @api annotation for block used in layout

### DIFF
--- a/Block/Adminhtml/Edit/Tab/Nodes.php
+++ b/Block/Adminhtml/Edit/Tab/Nodes.php
@@ -11,6 +11,9 @@ use Snowdog\Menu\Model\Menu\Node\Image\File as ImageFile;
 use Snowdog\Menu\Model\NodeTypeProvider;
 use Snowdog\Menu\Model\VueProvider;
 
+/**
+ * @api
+ */
 class Nodes extends Template implements TabInterface
 {
     const IMAGE_UPLOAD_URL = 'snowmenu/node/uploadimage';


### PR DESCRIPTION
This is issue when running static tests for M2 instance with this module enabled. Following command is executed (from `dev/tests/static` folder):

```
php -d memory_limit=-1 ../../../../code/vendor/bin/phpunit -c phpunit.xml --testsuite "Code Integrity Tests" --filter 'PublicCodeTest'
```

Expected output:

```
OK (3369 tests, 0 assertions)
```

Current result:

```
There was 1 failure:

1) Magento\Test\Integrity\PublicCodeTest::testAllBlocksReferencedInLayoutArePublic with data set "vendor/snowdog/module-menu/view/adminhtml/layout/snowmenu_menu_edit.xml" ('/app/vendor/snowdog/module-me...it.xml')
Layout file '/app/vendor/snowdog/module-menu/view/adminhtml/layout/snowmenu_menu_edit.xml' uses following blocks that are not marked with @api annotation:
Snowdog\Menu\Block\Adminhtml\Edit\Tab\Nodes

/app/dev/tests/static/testsuite/Magento/Test/Integrity/PublicCodeTest.php:81

FAILURES!
Tests: 3369, Assertions: 1, Failures: 1.
```

This commit fixes the issue.