### PR TITLE
#103904 - fix category tree import when page url includes index.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Fixed
+-  category tree import when page url includes index.php (DEV-103904)
 
 ## [2.24.1] - 2023-12-05
 ### Fixed

--- a/view/adminhtml/web/js/mixins/modal-mixin.js
+++ b/view/adminhtml/web/js/mixins/modal-mixin.js
@@ -35,11 +35,11 @@ define([
                   vueApp = registry.get('vueApp'),
                   categoryId = parseInt(form.data.category_id),
                   depth = parseInt(form.data.depth),
-                  adminPath = window.location.pathname.split('/')[1]
+                  adminPath = window.location.pathname.split('/snowmenu')[0]
 
                 $.ajax({
                   showLoader: true,
-                  url: '/' + adminPath + '/snowmenu/menu/importCategories',
+                  url: adminPath + '/snowmenu/menu/importCategories',
                   data: {
                     category_id: categoryId,
                     depth: depth


### PR DESCRIPTION
I think the issue is here: https://github.com/SnowdogApps/magento2-menu/blob/develop/view/adminhtml/web/js/mixins/modal-mixin.js#L38
it takes current admin URL and split it by / and take the 2nd position, I can see that path is:
"/index.php/admin/snowmenu/menu/edit/menu_id/3/key/7a91605d81de1ca8251abef5985d42e0baeaef7f29566b15078b496b47581112/"
so it takes index.php string since 1st char from the above string is / so 1st position is empty and 2nd is index.php

As a workaround we enabled Use Web Server Rewrites to remove index.php from URLs, but we need to make "Import from category tree" feature work with index.php in URL as well