### PR TITLE
Automatically open collapsed menu node when dragging another node inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `width` and `height` attributes to menu node images (DEV-102271)
 - Snowdog branding in admin panel (DEV-105762)
+- Automatically open collapsed menu node when dragging another node inside (DEV-101986)
 
 ## [2.26.0] - 2024-03-29
 ### Fixed

--- a/view/adminhtml/web/vue/nested-list.vue
+++ b/view/adminhtml/web/vue/nested-list.vue
@@ -9,13 +9,18 @@
         :wrapper="list"
         :class="{'selected': selectedItem === item}"
     >
-        <div class="panel">
+        <div
+            class="panel"
+            @dragover="dragover"
+            @dragenter="dragenter"
+            @dragleave="dragleave"
+        >
             <div class="panel__heading">
                 <div
                     class="panel__collapse"
                     :class="{
                         'panel__collapse--up': collapsed,
-                        'panel__collapse--down': !collapsed,
+                        'panel__collapse--down': !collapsed || draggedOver,
                         'panel__collapse--none': item.columns.length == 0,
                     }"
                     @click.prevent="collapsed = !collapsed"
@@ -56,11 +61,11 @@
                 </div>
             </div>
 
-            <div v-show="!collapsed">
+            <div v-show="!collapsed || draggedOver">
                 <vddl-list
                     class="panel__body"
                     :list="item.columns"
-                    :drop="drop"
+                    :drop="handleDrop"
                     :external-sources="true"
                 >
                     <template v-if="editItem">
@@ -83,7 +88,7 @@
                             :selected-item="selectedItem"
                             :delete="deleteEvent"
                             :append="append"
-                            :drop="drop"
+                            :drop="handleDrop"
                             :config="config"
                         />
                     </template>
@@ -155,7 +160,9 @@
             data: function() {
                 return {
                     editItem: false,
-                    collapsed: true
+                    collapsed: true,
+                    draggedOver: false,
+                    dragCounter: 0,
                 }
             },
             methods: {
@@ -187,7 +194,25 @@
                 editNode: function() {
                     this.editItem = !this.editItem;
                     this.collapsed = !this.editItem;
-                }
+                },
+                dragover() {
+                    this.draggedOver = true;
+                },
+                dragenter() {
+                    this.dragCounter++;
+                },
+                dragleave() {
+                    this.dragCounter--;
+                    if (this.dragCounter === 0) {
+                        this.draggedOver = false;
+                    }
+                },
+                handleDrop(data) {
+                    this.drop(data)
+                    this.draggedOver = false;
+                    this.dragCounter = 0;
+                    this.collapsed = false;
+                },
             },
             template: template
         });

--- a/view/adminhtml/web/vue/nested-list.vue
+++ b/view/adminhtml/web/vue/nested-list.vue
@@ -163,6 +163,7 @@
                     collapsed: true,
                     draggedOver: false,
                     dragCounter: 0,
+                    isDragging: false,
                 }
             },
             methods: {
@@ -196,16 +197,24 @@
                     this.collapsed = !this.editItem;
                 },
                 dragover() {
-                    this.draggedOver = true;
+                    this.isDragging = true;
                 },
                 dragenter() {
                     this.dragCounter++;
+                    setTimeout(() => {
+                        if (this.isDragging) {
+                            this.draggedOver = true;
+                        }
+                    }, 500)
                 },
                 dragleave() {
                     this.dragCounter--;
-                    if (this.dragCounter === 0) {
-                        this.draggedOver = false;
-                    }
+                    this.isDragging = false;
+                    setTimeout(() => {
+                        if (this.dragCounter === 0) {
+                            this.draggedOver = false;
+                        }
+                    }, 500)
                 },
                 handleDrop(data) {
                     this.drop(data)


### PR DESCRIPTION
See https://gyazo.com/04093cb118cca63a7a23155158c5c9db.
Would be great to automatically expand menu node on hover when dragging another node inside parent node. Currently we need to open parent node first and then drag and drop another node inside.