### PR TITLE
Auto-populate node name field 

### DIFF
--- a/view/adminhtml/web/vue/field-type/autocomplete-lazy.vue
+++ b/view/adminhtml/web/vue/field-type/autocomplete-lazy.vue
@@ -226,13 +226,14 @@
                     }
 
                     if (option && typeof option === 'object') {
-                        this.item[this.itemKey] = option.value.toString();
+                        this.$set(this.item, this.itemKey, option.value.toString());
                     }
                     else if (option && typeof option === 'string') {
-                        this.item[this.itemKey] = option;
+                        this.$set(this.item, this.itemKey, option);
+                        this.$set(this.item, 'title', this.options.find(item => item.value === option)?.label);
                     }
                     else {
-                      this.item[this.itemKey] = this.defaultSelectedOption ? this.defaultSelectedOption.value.toString() : '';
+                        this.$set(this.item, this.itemKey, this.defaultSelectedOption ? this.defaultSelectedOption.value.toString() : '');
                     }
                 }
             },

--- a/view/adminhtml/web/vue/field-type/autocomplete.vue
+++ b/view/adminhtml/web/vue/field-type/autocomplete.vue
@@ -129,14 +129,16 @@
                     },
                     set(option) {
                         if (option && typeof option === 'object') {
-                            this.item[this.itemKey] = option.value.toString();
-                            this.item[this.itemIdKey] = option.id.toString();
+                            this.$set(this.item, this.itemKey, option.value.toString());
+                            this.$set(this.item, this.itemIdKey, option.id.toString());
+                            this.$set(this.item, 'title', option.label);
                         }
                         else if (option && typeof option === 'string') {
-                            this.item[this.itemKey] = option;
+                            this.$set(this.item, this.itemKey, option);
+                            this.$set(this.item, 'title', this.options.find(item => item.value === option)?.label);
                         }
                         else {
-                          this.item[this.itemKey] = this.defaultSelectedOption ? this.defaultSelectedOption.value.toString() : '';
+                            this.$set(this.item, this.itemKey, this.defaultSelectedOption ? this.defaultSelectedOption.value.toString() : '');
                         }
                     }
                 },


### PR DESCRIPTION
It would be great to auto-populate node name field after user selects category, category child, CMS page, CMS block or product. Users can edit this name after it has been auto-populated.

![image](https://github.com/SnowdogApps/magento2-menu/assets/49198312/4fa2948d-8071-4896-9d5e-36366d495bee)
