### PR TITLE
Removed excess quotation mark in class attribute

### DIFF
--- a/view/frontend/templates/hyva-topmenu-desktop/menu/sub_menu.phtml
+++ b/view/frontend/templates/hyva-topmenu-desktop/menu/sub_menu.phtml
@@ -56,7 +56,7 @@ $heroicons = $viewModels->require(\Hyva\Theme\ViewModel\HeroiconsOutline::class)
                 ?>
                 <li
                     class="
-                        <?= /* @noEscape */ (string) $nodeType === 'wrapper' ? $escaper->escapeHtmlAttr($nodeClasses) : '' ?>"
+                        <?= /* @noEscape */ (string) $nodeType === 'wrapper' ? $escaper->escapeHtmlAttr($nodeClasses) : '' ?>
                         <?= (/* @noEscape */ (string) $nodeType === 'wrapper') && (/* @noEscape */ (int) $level > 2) ? '-ml-4' : '' ?>
                     "
                 >


### PR DESCRIPTION
Removed the excess quotation mark from the class attribute. By removing the extra quotation mark, we ensure that the HTML is valid and styles are applied correctly.
This change is minor and should not impact any functionality. It corrects the HTML syntax to ensure proper rendering and styling.