### PR TITLE
add support for array-data in content

### DIFF
--- a/Api/Data/NodeInterface.php
+++ b/Api/Data/NodeInterface.php
@@ -82,7 +82,7 @@ interface NodeInterface
     /**
      * Set content
      *
-     * @param string $content
+     * @param string|array $content
      * @return $this
      */
     public function setContent($content);

--- a/Model/Menu/Node.php
+++ b/Model/Menu/Node.php
@@ -7,6 +7,7 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource as AbstractResource;
 use Magento\Framework\Registry;
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Serialize\SerializerInterface;
 use Snowdog\Menu\Api\Data\NodeInterface;
 
@@ -97,7 +98,13 @@ class Node extends AbstractModel implements NodeInterface, IdentityInterface
      */
     public function getContent()
     {
-        return $this->_getData(NodeInterface::CONTENT);
+        $content =  $this->_getData(NodeInterface::CONTENT);
+
+        if (strpos($content, '{') === 0 && strpos($content, '}') === strlen($content) - 1) {
+            $content = $this->serializer->unserialize($content) ?: $content;
+        }
+
+        return $content;
     }
 
     /**
@@ -105,6 +112,10 @@ class Node extends AbstractModel implements NodeInterface, IdentityInterface
      */
     public function setContent($content)
     {
+        if (is_array($content)) {
+            $content = $this->serializer->serialize($content);
+        }
+
         return $this->setData(NodeInterface::CONTENT, $content);
     }
 


### PR DESCRIPTION
with this PR it is possible to store arrays within the content-field of the Node-Entity. 

This is useful if it is required to store more information, than a single string. 

this helps developer to have structured data, which has not be converted from and to json manually. 