### PR TITLE
Add Resource Connection to __construct so that the connection table name comes through with any prefixes

### DIFF
--- a/Model/ResourceModel/Menu/Node.php
+++ b/Model/ResourceModel/Menu/Node.php
@@ -8,17 +8,21 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\Model\ResourceModel\Db\Context;
 use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\App\ResourceConnection;
 
 class Node extends AbstractDb
 {
     protected $serializer;
+    protected $resource;
 
     public function __construct(
         Context $context,
         SerializerInterface $serializer,
+        ResourceConnection $resource,
         $connectionName = null
     ) {
         $this->serializer = $serializer;
+        $this->resource = $resource;
         parent::__construct($context, $connectionName);
     }
 
@@ -29,8 +33,9 @@ class Node extends AbstractDb
 
     protected function _afterSave(AbstractModel $object)
     {
-        $connection = $this->getConnection();
-        $connection->delete('snowmenu_customer', ['node_id = ?' => $object->getNodeId()]);
+        $connection = $this->resource->getConnection();
+        $tableName  = $this->resource->getTableName('snowmenu_customer');
+        $connection->delete($tableName, ['node_id = ?' => $object->getNodeId()]);
 
         $nodeCustomerGroups = $object->getData('customer_groups');
         if ($nodeCustomerGroups && is_string($nodeCustomerGroups)) {
@@ -44,7 +49,7 @@ class Node extends AbstractDb
             ];
         }
         if ($nodeCustomerGroups) {
-            $connection->insertMultiple('snowmenu_customer', $insertData);
+            $connection->insertMultiple($tableName, $insertData);
         }
 
         return parent::_afterSave($object);


### PR DESCRIPTION
Resolves: https://github.com/SnowdogApps/magento2-menu/issues/346

Add Resource Connection to __construct so that the connection table name comes through with any prefixes

Currently, when installed on an instance with a database prefix, the node saving fails with table 'databasename.snowmenu_customer' not found.

This is because `$this->getConnection();` uses a resource that has been instantiated without the concept of Magento database prefixes. 

**Replication Steps**
1. Install Magento with database prefix.
2. Create Menu in admin panel.
3. Add Node type of custom url and fill out information
4. Hit Save.
5. Error `table 'databasename.snowmenu_customer' not found.` is show.

