### PR TITLE
Shorten long NODE cache tag

### DIFF
--- a/Model/Menu/Node.php
+++ b/Model/Menu/Node.php
@@ -12,7 +12,7 @@ use Snowdog\Menu\Api\Data\NodeInterface;
 
 class Node extends AbstractModel implements NodeInterface, IdentityInterface
 {
-    const CACHE_TAG = 'snowdog_menu_node';
+    const CACHE_TAG = 'smn';
 
     /**
      * @var SerializerInterface


### PR DESCRIPTION
In cases when menu contains many nodes, it adds tags to `'x-magento-tags`  header.
Causing errors related to max header size allowed in different services like Varnish or Nodejs

Shortening default tag length will lower the impact.
![image](https://github.com/user-attachments/assets/98a94083-e084-4211-8894-558efbb1b759)

Also can be addressed by increasing header size on Varnish.
Or nodejs, but in some versions it's reported to not working correctly like - https://github.com/nodejs/node/issues/47246 