### PR TITLE
feat: remove item.type limitation for image-upload

### DIFF
--- a/view/adminhtml/web/vue/menu-type.vue
+++ b/view/adminhtml/web/vue/menu-type.vue
@@ -79,7 +79,7 @@
             </div>
         </div>
 
-        <template v-if="showImage">
+        <template>
             <image-upload
                 id="image"
                 :item="item"
@@ -184,9 +184,6 @@
                 },
                 templateOptions() {
                     return this.templateOptionsData[this.item['type']] || [];
-                },
-                showImage() {
-                    return ['category', 'product', 'custom_url'].includes(this.item.type);
                 }
             },
             methods: {


### PR DESCRIPTION
Removes restrictions on item types for image uploads to enhance flexibility.

Refs: https://github.com/SnowdogApps/magento2-menu/issues/335