### PR TITLE
Fixed issue where assigning customer group to a category caused an error when trying to duplicate menu

### DIFF
--- a/Service/Menu/Cloner.php
+++ b/Service/Menu/Cloner.php
@@ -103,8 +103,12 @@ class Cloner
 
             foreach ($this->menuNodes->getList($menu) as $node) {
                 $nodeClone = $this->nodeFactory->create();
+                $data = $node->getData();
 
-                $nodeClone->setData($node->getData());
+                if (isset($data['customer_groups'])) {
+                    $data['customer_groups'] = json_encode((array)$data['customer_groups']);
+                }
+                $nodeClone->setData($data);
                 $nodeClone->setId(null);
                 $nodeClone->setMenuId($menuCloneId);
 


### PR DESCRIPTION
**Issue Description:**

When customer groups are assigned to a category in a Menu, attempting to duplicate that menu results an error. As a result, the menu cannot be duplicated successfully.

**Screenshot-1:**
![image](https://github.com/user-attachments/assets/e74a2757-31b2-4814-b6b4-67ffe650f408)

**Screenshot-2:**
![image](https://github.com/user-attachments/assets/c026ed6e-f7d8-404c-9433-9095d25fcae7)

**Screenshot-3:**
![image](https://github.com/user-attachments/assets/b215b57d-8f0a-4c6b-8ade-839678c39666)

**Steps to Reproduce:**

1. Take a clean shop.
2. Install snowdog/module-menu in the shop.
3. Go to Stores → Configuration → SNOWDOG → Menu → General and set Customer Groups Enabled to Yes. (See Screenshot-1)
4. Create menu, assign customer groups to a category, and save the menu. (See Screenshot-2)
5. Duplicate that menu and observe result( See Screenshot-3).

**Expected Results:**

The menu should duplicate successfully, even if customer groups are assigned to categories.

**Actual Results:**

An error occurs during the duplication process, and the menu cannot be duplicated.

**Additional Information:**

File path: snowdog/module-menu/Service/Menu/Cloner.php


When cloning the menu, the code at line 119 uses $nodeClone->setData($node->getData()); to copy all data. However, in the original menu, the customer_groups field is saved as a JSON string like ["0", "1", "2", "3"], but after cloning, it becomes a plain array or comma-separated values like 0,1,2,3. This difference in format causes the error “Unable to unserialize value. Error: Syntax error” when saving the cloned menu. To fix this, the customer_groups value should be converted back to a JSON string before saving the cloned node.

![image](https://github.com/user-attachments/assets/a6675dac-0106-4069-99f5-c3fe4c876ada)
