### PR TITLE
Fixed relative custom URL breaks when Magento store code is included in URLs

### DIFF
--- a/Block/NodeType/CustomUrl.php
+++ b/Block/NodeType/CustomUrl.php
@@ -112,4 +112,29 @@ HTML;
     {
         return __("Custom Url");
     }
+
+    /**
+    * @param int $nodeId
+    *
+    * @return string
+    */
+    public function getCustomUrl($nodeId)
+    {
+        $node = $this->nodes[$nodeId];
+        $nodeContent = $node->getContent();
+        $url = '';
+
+        if (
+            $nodeContent
+            && $nodeContent !== '#'
+            && stripos($nodeContent, 'javascript:void') === false
+            && !$this->isExternalUrl($nodeContent)
+        ) {
+            $url = $this->_storeManager->getStore()->getBaseUrl() . ltrim($nodeContent, '/');
+        } else {
+            $url = $nodeContent;
+        }
+
+        return $url;
+    }
 }

--- a/view/frontend/templates/hyva-menu-footer/menu/node_type/custom_url.phtml
+++ b/view/frontend/templates/hyva-menu-footer/menu/node_type/custom_url.phtml
@@ -12,15 +12,15 @@ $imageUrl = $block->getImageUrl();
 $imageAltText = $block->getImageAltText();
 $imageWidth = $block->getImageWidth();
 $imageHeight = $block->getImageHeight();
-$content = $block->getContent();
+$url = $block->getCustomUrl($nodeId);
 $title = $block->getTitle();
 $dataAttribute = 'data-menu="menu-' . $nodeId . '"';
 $nodeClasses = $block->getNodeClasses();
 ?>
 
-<?php if ($content): ?>
+<?php if ($url): ?>
     <?php if ($imageUrl): ?>
-        <a href="<?= $escaper->escapeUrl($content) ?>"
+        <a href="<?= $escaper->escapeUrl($url) ?>"
             class="transition-opacity group-hover:opacity-80"
             tabindex="-1"
             <?php if ($block->getTarget()): ?>
@@ -36,7 +36,7 @@ $nodeClasses = $block->getNodeClasses();
             />
         </a>
     <?php endif; ?>
-    <a href="<?= $escaper->escapeUrl($content) ?>"
+    <a href="<?= $escaper->escapeUrl($url) ?>"
         class="snowdog-menu-link <?= $escaper->escapeHtmlAttr($nodeClasses) ?>"
         <?php if ($nodeId): ?>
             data-menu="menu-<?= $escaper->escapeHtmlAttr($nodeId) ?>"

--- a/view/frontend/templates/hyva-topmenu-desktop/menu/node_type/custom_url.phtml
+++ b/view/frontend/templates/hyva-topmenu-desktop/menu/node_type/custom_url.phtml
@@ -12,15 +12,15 @@ $imageUrl = $block->getImageUrl();
 $imageAltText = $block->getImageAltText();
 $imageWidth = $block->getImageWidth();
 $imageHeight = $block->getImageHeight();
-$content = $block->getContent();
+$url = $block->getCustomUrl($nodeId);
 $title = $block->getTitle();
 $dataAttribute = 'data-menu="menu-' . $nodeId . '"';
 $nodeClasses = $block->getNodeClasses();
 ?>
 
-<?php if ($content): ?>
+<?php if ($url): ?>
     <?php if ($imageUrl): ?>
-        <a href="<?= $escaper->escapeUrl($content) ?>"
+        <a href="<?= $escaper->escapeUrl($url) ?>"
             class="block mb-2 transition-opacity group-hover:opacity-80"
             tabindex="-1"
             <?php if ($block->getTarget()): ?>
@@ -36,7 +36,7 @@ $nodeClasses = $block->getNodeClasses();
             />
         </a>
     <?php endif; ?>
-    <a href="<?= $escaper->escapeUrl($content) ?>"
+    <a href="<?= $escaper->escapeUrl($url) ?>"
         class="snowdog-menu-link <?= $escaper->escapeHtmlAttr($nodeClasses) ?>"
         <?php if ($nodeId): ?>
             data-menu="menu-<?= $escaper->escapeHtmlAttr($nodeId) ?>"

--- a/view/frontend/templates/hyva-topmenu-mobile/menu/node_type/custom_url.phtml
+++ b/view/frontend/templates/hyva-topmenu-mobile/menu/node_type/custom_url.phtml
@@ -8,15 +8,15 @@ use Snowdog\Menu\Block\NodeType\CustomUrl;
 ?>
 <?php
 $nodeId = $block->getId();
-$content = $block->getContent();
+$url = $block->getCustomUrl($nodeId);
 $title = $block->getTitle();
 $dataAttribute = 'data-menu="menu-' . $nodeId . '"';
 $nodeClasses = $block->getNodeClasses();
 ?>
 
-<?php if ($content): ?>
+<?php if ($url): ?>
     <a class="cursor-pointer snowdog-menu-link-topmenu-mobile <?= $escaper->escapeHtmlAttr($nodeClasses) ?>"
-        href="<?= $escaper->escapeUrl($content) ?>"
+        href="<?= $escaper->escapeUrl($url) ?>"
         <?php if ($block->getTarget()): ?>
             target="_blank"
             rel="noopener"

--- a/view/frontend/templates/menu/node_type/custom_url.phtml
+++ b/view/frontend/templates/menu/node_type/custom_url.phtml
@@ -13,7 +13,8 @@ $imageUrl = $block->getImageUrl();
 $imageAltText = $block->getImageAltText();
 $imageWidth = $block->getImageWidth();
 $imageHeight = $block->getImageHeight();
-$content = $block->getContent();
+$nodeId = $block->getId();
+$url = $block->getCustomUrl($nodeId);
 
 if ($block->getIsViewAllLink()) {
     $title = __('View All');
@@ -32,9 +33,9 @@ if ($block->getTarget()) {
 }
 $allAttributes = implode(' ', $attributes);
 ?>
-<?php if ($content): ?>
+<?php if ($url): ?>
     <a
-        href="<?= $block->escapeUrl($content); ?>"
+        href="<?= $block->escapeUrl($url); ?>"
         <?= $allAttributes; ?>
     >
         <?= $block->escapeHtml($title); ?>


### PR DESCRIPTION
### Description
When adding a Custom URL menu item, internal paths like /contact or contact didn’t include the store’s base URL when “Add Store Code to URLs” was enabled.

This caused links to break on non-default store views — for example, /contact rendered as /contact instead of /storeB/contact.

**Fix:**

- Added logic to resolve internal URLs with the correct store base URL (including store code).
- Updated templates to use the resolved URL method.
- External URLs (e.g., https://google.com) remain unaffected.

**Fixes** #376.