### PR TITLE
Changed processNodeObject function to public to allow Plugin hook classes

### DIFF
--- a/Service/Menu/SaveRequestProcessor.php
+++ b/Service/Menu/SaveRequestProcessor.php
@@ -159,7 +159,7 @@ class SaveRequestProcessor
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    private function processNodeObject(
+    public function processNodeObject(
         NodeInterface $nodeObject,
         array $nodeData,
         MenuInterface $menu,


### PR DESCRIPTION
Pull request for [this issue](https://github.com/SnowdogApps/magento2-menu/issues/381).

This change will allow making Plugin classes on the `processNodeObject` function and by doing so allow saving custom nodes added by other modules.