### PR TITLE
Setting the title after autocomplete selection now checks it it's empty first

### DIFF
--- a/view/adminhtml/web/vue/field-type/autocomplete-lazy.vue
+++ b/view/adminhtml/web/vue/field-type/autocomplete-lazy.vue
@@ -230,7 +230,9 @@
                     }
                     else if (option && typeof option === 'string') {
                         this.$set(this.item, this.itemKey, option);
-                        this.$set(this.item, 'title', this.options.find(item => item.value === option)?.label);
+                        if (!this.item.title) {
+                            this.$set(this.item, 'title', this.options.find(item => item.value === option)?.label);
+                        }
                     }
                     else {
                         this.$set(this.item, this.itemKey, this.defaultSelectedOption ? this.defaultSelectedOption.value.toString() : '');

--- a/view/adminhtml/web/vue/field-type/autocomplete.vue
+++ b/view/adminhtml/web/vue/field-type/autocomplete.vue
@@ -131,11 +131,15 @@
                         if (option && typeof option === 'object') {
                             this.$set(this.item, this.itemKey, option.value.toString());
                             this.$set(this.item, this.itemIdKey, option.id.toString());
-                            this.$set(this.item, 'title', option.label);
+                            if (!this.item.title) {
+                                this.$set(this.item, 'title', option.label);
+                            }
                         }
                         else if (option && typeof option === 'string') {
                             this.$set(this.item, this.itemKey, option);
-                            this.$set(this.item, 'title', this.options.find(item => item.value === option)?.label);
+                            if (!this.item.title) {
+                                this.$set(this.item, 'title', this.options.find(item => item.value === option)?.label);
+                            }
                         }
                         else {
                             this.$set(this.item, this.itemKey, this.defaultSelectedOption ? this.defaultSelectedOption.value.toString() : '');


### PR DESCRIPTION
When selecting an option in an autocomplete field the title is always overwritten, even if it's already filled.

This at first doesn't look like much, but if you open a menu node the "set" function for the autocomplete field is called immediately.
Which means the title will always reset to the name of the selected option in the autocomplete.
This will reset any custom changes made to the title.

The PR is for [this issue](https://github.com/SnowdogApps/magento2-menu/issues/382).