### PR TITLE
Fix GraphQL node loading for duplicate identifiers and add cms block content

### DIFF
--- a/Model/GraphQl/Resolver/DataProvider/Node.php
+++ b/Model/GraphQl/Resolver/DataProvider/Node.php
@@ -21,6 +21,7 @@ class Node
     const URL_KEY = 'url_key';
 
     const NODE_TYPE_CUSTOM_URL = 'custom_url';
+    const NODE_TYPE_CMS_BLOCK = 'cms_block';
 
     /**
      * @var NodeRepositoryInterface
@@ -74,7 +75,7 @@ class Node
             );
         }
 
-        $nodes = $this->nodeRepository->getByIdentifier($identifier);
+        $nodes = $this->nodeRepository->getByMenu((int) $menu->getId());
         $this->loadModels($nodes, $storeId);
         foreach ($nodes as $node) {
             if ($node->getIsActive()) {
@@ -96,7 +97,7 @@ class Node
             NodeInterface::NODE_ID => (int) $node->getId(),
             NodeInterface::MENU_ID => (int) $node->getMenuId(),
             NodeInterface::TYPE => $node->getType(),
-            NodeInterface::CONTENT => $node->getContent(),
+            NodeInterface::CONTENT => $this->getContent($node),
             NodeInterface::CLASSES => $node->getClasses(),
             NodeInterface::PARENT_ID => (int) $node->getParentId(),
             NodeInterface::POSITION => (int) $node->getPosition(),
@@ -116,6 +117,22 @@ class Node
             NodeInterface::CUSTOMER_GROUPS => $node->getCustomerGroups(),
             NodeInterface::HIDE_IF_EMPTY => $node->getHideIfEmpty(),
         ];
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @return string|null
+     */
+    private function getContent(NodeInterface $node): ?string
+    {
+        if (
+            $node->getType() === self::NODE_TYPE_CMS_BLOCK
+            && isset($this->loadedModels[$node->getType()][$node->getContent()])
+        ) {
+            return $this->loadedModels[$node->getType()][$node->getContent()];
+        }
+
+        return $node->getContent();
     }
 
     /**
@@ -156,7 +173,10 @@ class Node
      */
     private function getUrlKey(NodeInterface $node): ?string
     {
-        if (in_array($node->getType(), TypeModel::TYPES)) {
+        if (
+            in_array($node->getType(), TypeModel::TYPES)
+            && $node->getType() !== self::NODE_TYPE_CMS_BLOCK
+        ) {
             if (!isset($this->loadedModels[$node->getType()][$node->getContent()])) {
                 return null;
             }

--- a/Model/GraphQl/Resolver/DataProvider/Node/TypeModel.php
+++ b/Model/GraphQl/Resolver/DataProvider/Node/TypeModel.php
@@ -6,29 +6,68 @@ namespace Snowdog\Menu\Model\GraphQl\Resolver\DataProvider\Node;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Cms\Api\Data\PageInterface;
+use Magento\Cms\Model\Template\FilterProvider;
 
 class TypeModel
 {
-    const TYPES = ["category", "product", "cms_page"];
+    const TYPES = ["category", "product", "cms_page", "cms_block"];
+
+    const TYPE_CMS_BLOCK = 'cms_block';
 
     /**
      * @var \Snowdog\Menu\Model\ResourceModel\NodeType\AbstractNode[]
      */
     private $typeModels = [];
 
+    /**
+     * @var FilterProvider
+     */
+    private $filterProvider;
+
     public function __construct(
+        FilterProvider $filterProvider,
         array $typeModels = []
     ) {
+        $this->filterProvider = $filterProvider;
         $this->typeModels = $typeModels;
     }
 
     public function getModels($type, $modelIds, $storeId)
     {
         if (isset($this->typeModels[$type])) {
-            return $this->typeModels[$type]->fetchData($storeId, $modelIds);
+            $models = $this->typeModels[$type]->fetchData($storeId, $modelIds);
+
+            if ($type === self::TYPE_CMS_BLOCK) {
+                return $this->prepareCmsBlockModels($models, (int) $storeId);
+            }
+
+            return $models;
         }
 
         return [];
+    }
+
+    /**
+     * @param array $models
+     * @param int $storeId
+     * @return array
+     */
+    private function prepareCmsBlockModels(array $models, int $storeId): array
+    {
+        $preparedModels = [];
+
+        foreach ($models as $model) {
+            if (!isset($model['identifier'])) {
+                continue;
+            }
+
+            $preparedModels[$model['identifier']] = $this->filterProvider
+                ->getBlockFilter()
+                ->setStoreId($storeId)
+                ->filter($model['content'] ?? '');
+        }
+
+        return $preparedModels;
     }
 
     public function getModelUrlKey($type, $model): ?string

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -23,6 +23,7 @@
             <argument name="typeModels" xsi:type="array">
                 <item name="product" xsi:type="object">Snowdog\Menu\Model\ResourceModel\NodeType\Product</item>
                 <item name="category" xsi:type="object">Snowdog\Menu\Model\ResourceModel\NodeType\Category</item>
+                <item name="cms_block" xsi:type="object">Snowdog\Menu\Model\ResourceModel\NodeType\CmsBlock</item>
                 <item name="cms_page" xsi:type="object">Snowdog\Menu\Model\ResourceModel\NodeType\CmsPage</item>
             </argument>
         </arguments>


### PR DESCRIPTION
**Summary**
  This PR improves GraphQL support for menu nodes in two areas:

  - adds support for cms_block node content
  - fixes node loading for multi-store setups by loading nodes by resolved menu_id

  **Why**
  In multi-store Magento setups, different menus may use the same identifier across stores. The GraphQL resolver correctly resolves the menu in the current store context first,
  but then loads nodes again by identifier. This may return nodes from other menus that share the same identifier.

  Also, cms_block nodes currently do not return rendered block content in GraphQL.

  **Changes**

  - register cms_block in GraphQL TypeModel
  - load CMS block data through Snowdog\Menu\Model\ResourceModel\NodeType\CmsBlock
  - render CMS block content with FilterProvider before returning it in GraphQL
  - keep url_key unchanged for cms_block nodes
  - replace getByIdentifier() with getByMenu() after resolving the menu entity

  **Validation**
  Validated manually in a real Magento project:

  - cms_block nodes return rendered content in GraphQL
  - GraphQL returns nodes only for the resolved menu in the current store context, even when other stores use the same menu identifier