### PR TITLE
Fix: addresses review issues from PR #360 (translation improvements)

### DIFF
--- a/Api/Data/NodeTranslationInterface.php
+++ b/Api/Data/NodeTranslationInterface.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Api\Data;
+
+interface NodeTranslationInterface
+{
+    public const TRANSLATION_ID = 'translation_id';
+    public const NODE_ID = 'node_id';
+    public const STORE_ID = 'store_id';
+    public const TITLE = 'title';
+    public const CREATED_AT = 'created_at';
+    public const UPDATED_AT = 'updated_at';
+
+    /**
+     * @return int|null
+     */
+    public function getTranslationId(): ?int;
+
+    /**
+     * @param int $id
+     * @return NodeTranslationInterface
+     */
+    public function setTranslationId(int $id): NodeTranslationInterface;
+
+    /**
+     * @return int
+     */
+    public function getNodeId(): int;
+
+    /**
+     * @param int $nodeId
+     * @return NodeTranslationInterface
+     */
+    public function setNodeId(int $nodeId): NodeTranslationInterface;
+
+    /**
+     * @return int
+     */
+    public function getStoreId(): int;
+
+    /**
+     * @param int $storeId
+     * @return NodeTranslationInterface
+     */
+    public function setStoreId(int $storeId): NodeTranslationInterface;
+
+    /**
+     * @return string|null
+     */
+    public function getTitle(): ?string;
+
+    /**
+     * @param string|null $title
+     * @return NodeTranslationInterface
+     */
+    public function setTitle(?string $title): NodeTranslationInterface;
+
+    /**
+     * @return string
+     */
+    public function getCreatedAt(): string;
+
+    /**
+     * @param string $createdAt
+     * @return NodeTranslationInterface
+     */
+    public function setCreatedAt(string $createdAt): NodeTranslationInterface;
+
+    /**
+     * @return string
+     */
+    public function getUpdatedAt(): string;
+
+    /**
+     * @param string $updatedAt
+     * @return NodeTranslationInterface
+     */
+    public function setUpdatedAt(string $updatedAt): NodeTranslationInterface;
+}

--- a/Api/Data/NodeTranslationInterface.php
+++ b/Api/Data/NodeTranslationInterface.php
@@ -5,23 +5,9 @@ namespace Snowdog\Menu\Api\Data;
 
 interface NodeTranslationInterface
 {
-    public const TRANSLATION_ID = 'translation_id';
     public const NODE_ID = 'node_id';
     public const STORE_ID = 'store_id';
     public const TITLE = 'title';
-    public const CREATED_AT = 'created_at';
-    public const UPDATED_AT = 'updated_at';
-
-    /**
-     * @return int|null
-     */
-    public function getTranslationId(): ?int;
-
-    /**
-     * @param int $id
-     * @return NodeTranslationInterface
-     */
-    public function setTranslationId(int $id): NodeTranslationInterface;
 
     /**
      * @return int
@@ -51,30 +37,8 @@ interface NodeTranslationInterface
     public function getTitle(): ?string;
 
     /**
-     * @param string|null $title
+     * @param string $title
      * @return NodeTranslationInterface
      */
-    public function setTitle(?string $title): NodeTranslationInterface;
-
-    /**
-     * @return string
-     */
-    public function getCreatedAt(): string;
-
-    /**
-     * @param string $createdAt
-     * @return NodeTranslationInterface
-     */
-    public function setCreatedAt(string $createdAt): NodeTranslationInterface;
-
-    /**
-     * @return string
-     */
-    public function getUpdatedAt(): string;
-
-    /**
-     * @param string $updatedAt
-     * @return NodeTranslationInterface
-     */
-    public function setUpdatedAt(string $updatedAt): NodeTranslationInterface;
+    public function setTitle(string $title): NodeTranslationInterface;
 }

--- a/Api/Data/NodeTranslationInterface.php
+++ b/Api/Data/NodeTranslationInterface.php
@@ -5,9 +5,23 @@ namespace Snowdog\Menu\Api\Data;
 
 interface NodeTranslationInterface
 {
+    public const TRANSLATION_ID = 'translation_id';
     public const NODE_ID = 'node_id';
     public const STORE_ID = 'store_id';
     public const TITLE = 'title';
+    public const CREATED_AT = 'created_at';
+    public const UPDATED_AT = 'updated_at';
+
+    /**
+     * @return int|null
+     */
+    public function getTranslationId(): ?int;
+
+    /**
+     * @param int $id
+     * @return NodeTranslationInterface
+     */
+    public function setTranslationId(int $id): NodeTranslationInterface;
 
     /**
      * @return int
@@ -41,4 +55,26 @@ interface NodeTranslationInterface
      * @return NodeTranslationInterface
      */
     public function setTitle(string $title): NodeTranslationInterface;
+
+    /**
+     * @return string
+     */
+    public function getCreatedAt(): string;
+
+    /**
+     * @param string $createdAt
+     * @return NodeTranslationInterface
+     */
+    public function setCreatedAt(string $createdAt): NodeTranslationInterface;
+
+    /**
+     * @return string
+     */
+    public function getUpdatedAt(): string;
+
+    /**
+     * @param string $updatedAt
+     * @return NodeTranslationInterface
+     */
+    public function setUpdatedAt(string $updatedAt): NodeTranslationInterface;
 }

--- a/Api/NodeTranslationRepositoryInterface.php
+++ b/Api/NodeTranslationRepositoryInterface.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Snowdog\Menu\Api;
 
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SearchResultsInterface;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -82,4 +84,10 @@ interface NodeTranslationRepositoryInterface
      * @throws CouldNotDeleteException
      */
     public function deleteByNodeId(int $nodeId): bool;
+
+    /**
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return SearchResultsInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultsInterface;
 }

--- a/Api/NodeTranslationRepositoryInterface.php
+++ b/Api/NodeTranslationRepositoryInterface.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Api;
+
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Snowdog\Menu\Api\Data\NodeTranslationInterface;
+
+interface NodeTranslationRepositoryInterface
+{
+    /**
+     * Save node translation
+     *
+     * @param NodeTranslationInterface $translation
+     * @return NodeTranslationInterface
+     * @throws CouldNotSaveException
+     */
+    public function save(NodeTranslationInterface $translation): NodeTranslationInterface;
+
+    /**
+     * Get node translation by ID
+     *
+     * @param int $translationId
+     * @return NodeTranslationInterface
+     * @throws NoSuchEntityException
+     */
+    public function getById(int $translationId): NodeTranslationInterface;
+
+    /**
+     * Get node translation by node ID and store ID
+     *
+     * @param int $nodeId
+     * @param int $storeId
+     * @return NodeTranslationInterface
+     * @throws NoSuchEntityException
+     */
+    public function getByNodeAndStore(int $nodeId, int $storeId): NodeTranslationInterface;
+
+    /**
+     * Get all translations for multiple nodes in a specific store
+     *
+     * @param array $nodeIds
+     * @param int $storeId
+     * @return NodeTranslationInterface[]
+     */
+    public function getByNodeIds(array $nodeIds, int $storeId): array;
+
+    /**
+     * Get all translations for a node
+     *
+     * @param int $nodeId
+     * @return NodeTranslationInterface[]
+     */
+    public function getByNodeId(int $nodeId): array;
+
+    /**
+     * Delete node translation
+     *
+     * @param NodeTranslationInterface $translation
+     * @return bool
+     * @throws CouldNotDeleteException
+     */
+    public function delete(NodeTranslationInterface $translation): bool;
+
+    /**
+     * Delete node translation by ID
+     *
+     * @param int $translationId
+     * @return bool
+     * @throws CouldNotDeleteException
+     * @throws NoSuchEntityException
+     */
+    public function deleteById(int $translationId): bool;
+
+    /**
+     * Delete all translations for a node
+     *
+     * @param int $nodeId
+     * @return bool
+     * @throws CouldNotDeleteException
+     */
+    public function deleteByNodeId(int $nodeId): bool;
+}

--- a/Block/Adminhtml/Edit/Tab/Nodes.php
+++ b/Block/Adminhtml/Edit/Tab/Nodes.php
@@ -192,26 +192,10 @@ class Nodes extends Template implements TabInterface
         $nodes = $data[$level][$parent];
         $menu = [];
 
-        // Create store view lookup array
+        // Create store view lookup array keyed by store ID
         $storeViewLabels = [];
-        $websites = $this->systemStore->getWebsiteCollection();
-        $websiteNames = [];
-
-        // Create website name lookup array
-        foreach ($websites as $website) {
-            $websiteNames[$website->getId()] = $website->getName();
-        }
-
-        foreach ($this->systemStore->getStoreCollection() as $store) {
-            if ($store->isActive()) {
-                $websiteName = isset($websiteNames[$store->getWebsiteId()])
-                    ? $websiteNames[$store->getWebsiteId()]
-                    : '';
-                $storeViewLabels[$store->getId()] = [
-                    'value' => $store->getId(),
-                    'label' => sprintf('%s -> %s', $websiteName, $store->getName())
-                ];
-            }
+        foreach ($this->getStoreViews() as $storeView) {
+            $storeViewLabels[$storeView['value']] = $storeView;
         }
 
         foreach ($nodes as $node) {

--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -15,6 +15,8 @@ use Snowdog\Menu\Model\Menu\Node\Image\File as ImageFile;
 use Snowdog\Menu\Model\NodeTypeProvider;
 use Snowdog\Menu\Model\TemplateResolver;
 use Magento\Store\Model\Store;
+use Snowdog\Menu\Api\NodeTranslationRepositoryInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -40,9 +42,19 @@ class Menu extends Template implements DataObject\IdentityInterface
      */
     private $nodeTypeProvider;
 
-    private $nodes;
+    /**
+     * @var NodeTranslationRepositoryInterface
+     */
+    private $nodeTranslationRepository;
 
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    private $nodes;
     private $menu = null;
+    private $nodeTranslations = [];
 
     /**
      * @var EventManager
@@ -97,6 +109,8 @@ class Menu extends Template implements DataObject\IdentityInterface
         ImageFile $imageFile,
         Escaper $escaper,
         Context $httpContext,
+        NodeTranslationRepositoryInterface $nodeTranslationRepository,
+        StoreManagerInterface $storeManager,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -110,6 +124,8 @@ class Menu extends Template implements DataObject\IdentityInterface
         $this->setTemplate($this->getMenuTemplate($this->_template));
         $this->submenuTemplate = $this->getSubmenuTemplate();
         $this->httpContext = $httpContext;
+        $this->nodeTranslationRepository = $nodeTranslationRepository;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -392,7 +408,7 @@ class Menu extends Template implements DataObject\IdentityInterface
         $level = $node->getLevel();
         $isRoot = 0 == $level;
         $nodeBlock->setId($node->getNodeId())
-            ->setTitle($node->getTitle())
+            ->setTitle($this->getNodeTitle($node))
             ->setLevel($level)
             ->setIsRoot($isRoot)
             ->setIsParent((bool) $node->getIsParent())
@@ -447,6 +463,8 @@ class Menu extends Template implements DataObject\IdentityInterface
         $customerGroupEnabled = $this->_scopeConfig->getValue(self::XML_SNOWMENU_GENERAL_CUSTOMER_GROUPS);
         $result = [];
         $types = [];
+        $nodeIds = [];
+
         foreach ($nodes as $node) {
             if (!$node->getIsActive()) {
                 continue;
@@ -455,6 +473,7 @@ class Menu extends Template implements DataObject\IdentityInterface
                 continue;
             }
 
+            $nodeIds[] = $node->getId();
             $level = $node->getLevel();
             $parent = $node->getParentId() ?: 0;
             if (!isset($result[$level])) {
@@ -470,6 +489,16 @@ class Menu extends Template implements DataObject\IdentityInterface
             }
             $types[$type][] = $node;
         }
+
+        // Load all translations for the current store in a single query
+        if (!empty($nodeIds)) {
+            $storeId = (int)$this->storeManager->getStore()->getId();
+            $collection = $this->nodeTranslationRepository->getByNodeIds($nodeIds, $storeId);
+            foreach ($collection as $translation) {
+                $this->nodeTranslations[$translation->getNodeId()] = $translation;
+            }
+        }
+
         $this->nodes = $result;
 
         foreach ($types as $type => $nodes) {
@@ -512,5 +541,23 @@ class Menu extends Template implements DataObject\IdentityInterface
     public function getCustomerGroupId()
     {
         return $this->httpContext->getValue(\Magento\Customer\Model\Context::CONTEXT_GROUP);
+    }
+
+    /**
+     * Get translated node title based on current store view
+     *
+     * @param NodeInterface $node
+     * @return string
+     */
+    private function getNodeTitle(NodeInterface $node): string
+    {
+        $nodeId = $node->getId();
+        if (isset($this->nodeTranslations[$nodeId])) {
+            $title = $this->nodeTranslations[$nodeId]->getTitle();
+            if ($title) {
+                return $title;
+            }
+        }
+        return $node->getTitle();
     }
 }

--- a/Model/ImportExport/Processor/Export/Node.php
+++ b/Model/ImportExport/Processor/Export/Node.php
@@ -10,6 +10,7 @@ use Magento\Framework\Api\SortOrderBuilder;
 use Snowdog\Menu\Api\Data\NodeInterface;
 use Snowdog\Menu\Api\NodeRepositoryInterface;
 use Snowdog\Menu\Model\ImportExport\Processor\Export\Node\Tree as NodeTree;
+use Snowdog\Menu\Model\ImportExport\Processor\Export\Node\DataProcessor;
 
 class Node
 {
@@ -40,16 +41,23 @@ class Node
      */
     private $nodeTree;
 
+    /**
+     * @var DataProcessor
+     */
+    private $dataProcessor;
+
     public function __construct(
         SearchCriteriaBuilder $searchCriteriaBuilder,
         SortOrderBuilder $sortOrderBuilder,
         NodeRepositoryInterface $nodeRepository,
-        NodeTree $nodeTree
+        NodeTree $nodeTree,
+        DataProcessor $dataProcessor
     ) {
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->sortOrderBuilder = $sortOrderBuilder;
         $this->nodeRepository = $nodeRepository;
         $this->nodeTree = $nodeTree;
+        $this->dataProcessor = $dataProcessor;
     }
 
     public function getList(int $menuId): array
@@ -65,6 +73,10 @@ class Node
             ->create();
 
         $nodes = $this->nodeRepository->getList($searchCriteria)->getItems();
+
+        if (!empty($nodes)) {
+            $this->dataProcessor->preloadTranslations($nodes);
+        }
 
         return $nodes ? $this->nodeTree->get($nodes) : [];
     }

--- a/Model/ImportExport/Processor/Export/Node/DataProcessor.php
+++ b/Model/ImportExport/Processor/Export/Node/DataProcessor.php
@@ -6,6 +6,7 @@ namespace Snowdog\Menu\Model\ImportExport\Processor\Export\Node;
 
 use Snowdog\Menu\Api\Data\NodeInterface;
 use Snowdog\Menu\Model\ImportExport\Processor\Export\Node\TypeContent;
+use Snowdog\Menu\Model\ImportExport\Processor\ExtendedFields;
 
 class DataProcessor
 {
@@ -13,10 +14,23 @@ class DataProcessor
      * @var TypeContent
      */
     private $typeContent;
+    private TranslationProcessor $translationProcessor;
 
-    public function __construct(TypeContent $typeContent)
-    {
+    public function __construct(
+        TypeContent $typeContent,
+        TranslationProcessor $translationProcessor
+    ) {
         $this->typeContent = $typeContent;
+        $this->translationProcessor = $translationProcessor;
+    }
+
+    public function preloadTranslations(array $nodes): void
+    {
+        $nodeIds = array_map(
+            fn($node) => (int)$node->getId(),
+            $nodes
+        );
+        $this->translationProcessor->preloadTranslations($nodeIds);
     }
 
     public function getData(array $data): array
@@ -25,6 +39,14 @@ class DataProcessor
             $data[NodeInterface::TYPE],
             $data[NodeInterface::CONTENT]
         );
+
+        $translations = $this->translationProcessor->getTranslations(
+            (int)$data[NodeInterface::NODE_ID]
+        );
+
+        if (!empty($translations)) {
+            $data[ExtendedFields::TRANSLATIONS] = $translations;
+        }
 
         return $data;
     }

--- a/Model/ImportExport/Processor/Export/Node/TranslationProcessor.php
+++ b/Model/ImportExport/Processor/Export/Node/TranslationProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Model\ImportExport\Processor\Export\Node;
+
+use Snowdog\Menu\Api\NodeTranslationRepositoryInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class TranslationProcessor
+{
+    private NodeTranslationRepositoryInterface $nodeTranslationRepository;
+    private StoreManagerInterface $storeManager;
+    private array $translationsCache = [];
+
+    public function __construct(
+        NodeTranslationRepositoryInterface $nodeTranslationRepository,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->nodeTranslationRepository = $nodeTranslationRepository;
+        $this->storeManager = $storeManager;
+    }
+
+    public function preloadTranslations(array $nodeIds): void
+    {
+        if (empty($nodeIds)) {
+            return;
+        }
+
+        $stores = $this->storeManager->getStores();
+        foreach ($stores as $store) {
+            $translations = $this->nodeTranslationRepository->getByNodeIds($nodeIds, (int)$store->getId());
+            foreach ($translations as $translation) {
+                $nodeId = $translation->getNodeId();
+                if ($translation->getTitle()) {
+                    $this->translationsCache[$nodeId][$store->getCode()] = $translation->getTitle();
+                }
+            }
+        }
+    }
+
+    public function getTranslations(int $nodeId): array
+    {
+        return $this->translationsCache[$nodeId] ?? [];
+    }
+}

--- a/Model/ImportExport/Processor/ExtendedFields.php
+++ b/Model/ImportExport/Processor/ExtendedFields.php
@@ -9,8 +9,13 @@ namespace Snowdog\Menu\Model\ImportExport\Processor;
  */
 class ExtendedFields
 {
-    const STORES = 'stores';
     const NODES = 'nodes';
+    const STORES = 'stores';
+    const TRANSLATIONS = 'translations';
 
-    const FIELDS = [self::STORES, self::NODES];
+    const FIELDS = [
+        self::NODES,
+        self::STORES,
+        self::TRANSLATIONS
+    ];
 }

--- a/Model/ImportExport/Processor/Import/Node/TranslationProcessor.php
+++ b/Model/ImportExport/Processor/Import/Node/TranslationProcessor.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Model\ImportExport\Processor\Import\Node;
+
+use Magento\Store\Model\StoreManagerInterface;
+use Snowdog\Menu\Api\NodeTranslationRepositoryInterface;
+use Snowdog\Menu\Api\Data\NodeTranslationInterfaceFactory;
+
+class TranslationProcessor
+{
+    private StoreManagerInterface $storeManager;
+    private NodeTranslationRepositoryInterface $nodeTranslationRepository;
+    private NodeTranslationInterfaceFactory $nodeTranslationFactory;
+    private array $storeCodeToId = [];
+
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        NodeTranslationRepositoryInterface $nodeTranslationRepository,
+        NodeTranslationInterfaceFactory $nodeTranslationFactory
+    ) {
+        $this->storeManager = $storeManager;
+        $this->nodeTranslationRepository = $nodeTranslationRepository;
+        $this->nodeTranslationFactory = $nodeTranslationFactory;
+        $this->initializeStoreMap();
+    }
+
+    private function initializeStoreMap(): void
+    {
+        $stores = $this->storeManager->getStores();
+        foreach ($stores as $store) {
+            $this->storeCodeToId[$store->getCode()] = (int)$store->getId();
+        }
+    }
+
+    public function processTranslations(int $nodeId, array $translations): void
+    {
+        if (empty($translations)) {
+            return;
+        }
+
+        foreach ($translations as $storeCode => $title) {
+            if (!isset($this->storeCodeToId[$storeCode])) {
+                continue; // Skip if store code doesn't exist
+            }
+
+            $storeId = $this->storeCodeToId[$storeCode];
+            $translation = $this->nodeTranslationFactory->create();
+            $translation->setNodeId($nodeId)
+                ->setStoreId($storeId)
+                ->setTitle($title);
+
+            $this->nodeTranslationRepository->save($translation);
+        }
+    }
+}

--- a/Model/ImportExport/Processor/Import/Node/TranslationProcessor.php
+++ b/Model/ImportExport/Processor/Import/Node/TranslationProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Snowdog\Menu\Model\ImportExport\Processor\Import\Node;
 
 use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
 use Snowdog\Menu\Api\NodeTranslationRepositoryInterface;
 use Snowdog\Menu\Api\Data\NodeTranslationInterfaceFactory;
 
@@ -13,16 +14,19 @@ class TranslationProcessor
     private StoreManagerInterface $storeManager;
     private NodeTranslationRepositoryInterface $nodeTranslationRepository;
     private NodeTranslationInterfaceFactory $nodeTranslationFactory;
+    private LoggerInterface $logger;
     private array $storeCodeToId = [];
 
     public function __construct(
         StoreManagerInterface $storeManager,
         NodeTranslationRepositoryInterface $nodeTranslationRepository,
-        NodeTranslationInterfaceFactory $nodeTranslationFactory
+        NodeTranslationInterfaceFactory $nodeTranslationFactory,
+        LoggerInterface $logger
     ) {
         $this->storeManager = $storeManager;
         $this->nodeTranslationRepository = $nodeTranslationRepository;
         $this->nodeTranslationFactory = $nodeTranslationFactory;
+        $this->logger = $logger;
         $this->initializeStoreMap();
     }
 
@@ -51,7 +55,13 @@ class TranslationProcessor
                 ->setStoreId($storeId)
                 ->setTitle($title);
 
-            $this->nodeTranslationRepository->save($translation);
+            try {
+                $this->nodeTranslationRepository->save($translation);
+            } catch (\Exception $e) {
+                $this->logger->error(
+                    sprintf('Failed to save translation for node %d, store %s: %s', $nodeId, $storeCode, $e->getMessage())
+                );
+            }
         }
     }
 }

--- a/Model/ImportExport/Processor/Store.php
+++ b/Model/ImportExport/Processor/Store.php
@@ -7,6 +7,7 @@ namespace Snowdog\Menu\Model\ImportExport\Processor;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Store
 {
@@ -16,13 +17,19 @@ class Store
     private $storeRepository;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @var array
      */
     private $cachedStores = [];
 
-    public function __construct(StoreRepositoryInterface $storeRepository)
+    public function __construct(StoreRepositoryInterface $storeRepository, StoreManagerInterface $storeManager)
     {
         $this->storeRepository = $storeRepository;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -44,5 +51,15 @@ class Store
         $this->cachedStores[$storeCode] = $store;
 
         return $store;
+    }
+
+    public function getIdByCode(string $storeCode): ?int
+    {
+        try {
+            $store = $this->storeManager->getStore($storeCode);
+            return (int) $store->getId();
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/Model/ImportExport/Processor/Store.php
+++ b/Model/ImportExport/Processor/Store.php
@@ -7,7 +7,6 @@ namespace Snowdog\Menu\Model\ImportExport\Processor;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
-use Magento\Store\Model\StoreManagerInterface;
 
 class Store
 {
@@ -17,19 +16,13 @@ class Store
     private $storeRepository;
 
     /**
-     * @var StoreManagerInterface
-     */
-    private $storeManager;
-
-    /**
      * @var array
      */
     private $cachedStores = [];
 
-    public function __construct(StoreRepositoryInterface $storeRepository, StoreManagerInterface $storeManager)
+    public function __construct(StoreRepositoryInterface $storeRepository)
     {
         $this->storeRepository = $storeRepository;
-        $this->storeManager = $storeManager;
     }
 
     /**
@@ -51,15 +44,5 @@ class Store
         $this->cachedStores[$storeCode] = $store;
 
         return $store;
-    }
-
-    public function getIdByCode(string $storeCode): ?int
-    {
-        try {
-            $store = $this->storeManager->getStore($storeCode);
-            return (int) $store->getId();
-        } catch (\Exception $e) {
-            return null;
-        }
     }
 }

--- a/Model/NodeTranslation.php
+++ b/Model/NodeTranslation.php
@@ -78,7 +78,7 @@ class NodeTranslation extends AbstractModel implements NodeTranslationInterface
     /**
      * @inheritDoc
      */
-    public function setTitle(?string $title): NodeTranslationInterface
+    public function setTitle(string $title): NodeTranslationInterface
     {
         return $this->setData(self::TITLE, $title);
     }

--- a/Model/NodeTranslation.php
+++ b/Model/NodeTranslation.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use Snowdog\Menu\Api\Data\NodeTranslationInterface;
+use Snowdog\Menu\Model\ResourceModel\NodeTranslation as NodeTranslationResource;
+
+class NodeTranslation extends AbstractModel implements NodeTranslationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    protected function _construct()
+    {
+        $this->_init(NodeTranslationResource::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTranslationId(): ?int
+    {
+        return $this->getData(self::TRANSLATION_ID) === null
+            ? null
+            : (int)$this->getData(self::TRANSLATION_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setTranslationId(int $id): NodeTranslationInterface
+    {
+        return $this->setData(self::TRANSLATION_ID, $id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNodeId(): int
+    {
+        return (int)$this->getData(self::NODE_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setNodeId(int $nodeId): NodeTranslationInterface
+    {
+        return $this->setData(self::NODE_ID, $nodeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStoreId(): int
+    {
+        return (int)$this->getData(self::STORE_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setStoreId(int $storeId): NodeTranslationInterface
+    {
+        return $this->setData(self::STORE_ID, $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTitle(): ?string
+    {
+        return $this->getData(self::TITLE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setTitle(?string $title): NodeTranslationInterface
+    {
+        return $this->setData(self::TITLE, $title);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCreatedAt(): string
+    {
+        return (string)$this->getData(self::CREATED_AT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setCreatedAt(string $createdAt): NodeTranslationInterface
+    {
+        return $this->setData(self::CREATED_AT, $createdAt);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUpdatedAt(): string
+    {
+        return (string)$this->getData(self::UPDATED_AT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setUpdatedAt(string $updatedAt): NodeTranslationInterface
+    {
+        return $this->setData(self::UPDATED_AT, $updatedAt);
+    }
+
+    public function getValue(): string
+    {
+        return (string)$this->getData('value');
+    }
+
+    public function setValue(string $value): void
+    {
+        $this->setData('value', $value);
+    }
+}

--- a/Model/NodeTranslation.php
+++ b/Model/NodeTranslation.php
@@ -115,13 +115,4 @@ class NodeTranslation extends AbstractModel implements NodeTranslationInterface
         return $this->setData(self::UPDATED_AT, $updatedAt);
     }
 
-    public function getValue(): string
-    {
-        return (string)$this->getData('value');
-    }
-
-    public function setValue(string $value): void
-    {
-        $this->setData('value', $value);
-    }
 }

--- a/Model/NodeTranslationRepository.php
+++ b/Model/NodeTranslationRepository.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Model;
+
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Snowdog\Menu\Api\Data\NodeTranslationInterface;
+use Snowdog\Menu\Api\Data\NodeTranslationInterfaceFactory;
+use Snowdog\Menu\Api\NodeTranslationRepositoryInterface;
+use Snowdog\Menu\Model\ResourceModel\NodeTranslation as NodeTranslationResource;
+use Snowdog\Menu\Model\ResourceModel\NodeTranslation\Collection;
+use Snowdog\Menu\Model\ResourceModel\NodeTranslation\CollectionFactory;
+
+class NodeTranslationRepository implements NodeTranslationRepositoryInterface
+{
+    /**
+     * @var NodeTranslationResource
+     */
+    private NodeTranslationResource $resource;
+
+    /**
+     * @var NodeTranslationInterfaceFactory
+     */
+    private NodeTranslationInterfaceFactory $translationFactory;
+
+    /**
+     * @var CollectionFactory
+     */
+    private CollectionFactory $collectionFactory;
+
+    public function __construct(
+        NodeTranslationResource $resource,
+        NodeTranslationInterfaceFactory $translationFactory,
+        CollectionFactory $collectionFactory
+    ) {
+        $this->resource = $resource;
+        $this->translationFactory = $translationFactory;
+        $this->collectionFactory = $collectionFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function save(NodeTranslationInterface $translation): NodeTranslationInterface
+    {
+        try {
+            $this->resource->save($translation);
+        } catch (\Exception $e) {
+            throw new CouldNotSaveException(__('Could not save node translation: %1', $e->getMessage()));
+        }
+
+        return $translation;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getById(int $translationId): NodeTranslationInterface
+    {
+        $translation = $this->translationFactory->create();
+        $this->resource->load($translation, $translationId);
+
+        if (!$translation->getId()) {
+            throw new NoSuchEntityException(__('Node translation with ID "%1" does not exist.', $translationId));
+        }
+
+        return $translation;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getByNodeAndStore(int $nodeId, int $storeId): NodeTranslationInterface
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('node_id', $nodeId);
+        $collection->addFieldToFilter('store_id', $storeId);
+        $collection->setPageSize(1);
+
+        $translation = $collection->getFirstItem();
+
+        if (!$translation->getId()) {
+            throw new NoSuchEntityException(
+                __('Node translation for node ID "%1" and store ID "%2" does not exist.', $nodeId, $storeId)
+            );
+        }
+
+        return $translation;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getByNodeId(int $nodeId): array
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('node_id', $nodeId);
+
+        return $collection->getItems();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getByNodeIds(array $nodeIds, int $storeId): array
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('node_id', ['in' => $nodeIds]);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        return $collection->getItems();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(NodeTranslationInterface $translation): bool
+    {
+        try {
+            $this->resource->delete($translation);
+        } catch (\Exception $e) {
+            throw new CouldNotDeleteException(__('Could not delete node translation: %1', $e->getMessage()));
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteById(int $translationId): bool
+    {
+        return $this->delete($this->getById($translationId));
+    }
+
+    public function deleteByNodeId(int $nodeId): bool
+    {
+        try {
+            $collection = $this->collectionFactory->create();
+            $collection->addFieldToFilter('node_id', $nodeId);
+            foreach ($collection as $translation) {
+                $this->delete($translation);
+            }
+        } catch (\Exception $e) {
+            throw new CouldNotDeleteException(__('Could not delete node translations: %1', $e->getMessage()));
+        }
+        return true;
+    }
+}

--- a/Model/ResourceModel/NodeTranslation.php
+++ b/Model/ResourceModel/NodeTranslation.php
@@ -9,10 +9,20 @@ use Snowdog\Menu\Api\Data\NodeTranslationInterface;
 class NodeTranslation extends AbstractDb
 {
     /**
+     * @var string
+     */
+    public const TABLE_NAME = 'snowmenu_node_translation';
+
+    /**
+     * @var string
+     */
+    public const ID_FIELD_NAME = 'translation_id';
+
+    /**
      * @inheritDoc
      */
     protected function _construct()
     {
-        $this->_init('snowmenu_node_translation', 'translation_id');
+        $this->_init(self::TABLE_NAME, self::ID_FIELD_NAME);
     }
 }

--- a/Model/ResourceModel/NodeTranslation.php
+++ b/Model/ResourceModel/NodeTranslation.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Snowdog\Menu\Api\Data\NodeTranslationInterface;
+
+class NodeTranslation extends AbstractDb
+{
+    /**
+     * @inheritDoc
+     */
+    protected function _construct()
+    {
+        $this->_init('snowmenu_node_translation', 'translation_id');
+    }
+}

--- a/Model/ResourceModel/NodeTranslation/Collection.php
+++ b/Model/ResourceModel/NodeTranslation/Collection.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Model\ResourceModel\NodeTranslation;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Snowdog\Menu\Model\NodeTranslation;
+use Snowdog\Menu\Model\ResourceModel\NodeTranslation as NodeTranslationResource;
+
+class Collection extends AbstractCollection
+{
+    /**
+     * @inheritDoc
+     */
+    protected function _construct()
+    {
+        $this->_init(NodeTranslation::class, NodeTranslationResource::class);
+    }
+}

--- a/Plugin/Model/Menu/Node/AfterSave.php
+++ b/Plugin/Model/Menu/Node/AfterSave.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Snowdog\Menu\Plugin\Model\Menu\Node;
+
+use Snowdog\Menu\Api\NodeTranslationRepositoryInterface;
+use Snowdog\Menu\Api\Data\NodeTranslationInterface;
+use Snowdog\Menu\Api\Data\NodeTranslationInterfaceFactory;
+use Snowdog\Menu\Model\Menu\Node;
+
+class AfterSave
+{
+    /**
+     * @param NodeTranslationRepositoryInterface $nodeTranslationRepository
+     * @param NodeTranslationInterfaceFactory $nodeTranslationFactory
+     */
+    public function __construct(
+        private readonly NodeTranslationRepositoryInterface $nodeTranslationRepository,
+        private readonly NodeTranslationInterfaceFactory $nodeTranslationFactory
+    ) {}
+
+    /**
+     * Save translations after node is saved
+     *
+     * @param Node $subject
+     * @param Node $result
+     * @return Node
+     */
+    public function afterSave(Node $subject, Node $result): Node
+    {
+        $translations = $result->getData('translations');
+
+        if (!is_array($translations)) {
+            return $result;
+        }
+
+        $nodeId = (int)$result->getId();
+        $existingTranslations = $this->nodeTranslationRepository->getByNodeId($nodeId);
+        $existingTranslationMap = [];
+
+        // Create a map of existing translations by store ID for easy lookup
+        foreach ($existingTranslations as $translation) {
+            $storeId = $translation->getStoreId();
+            $existingTranslationMap[$storeId] = $translation;
+        }
+
+        // Process new/updated translations
+        foreach ($translations as $translation) {
+            if (!isset($translation['store_id']) || !isset($translation['value'])) {
+                continue;
+            }
+
+            $storeId = (int)$translation['store_id'];
+            $newValue = $translation['value'];
+
+            // If translation exists for this store
+            if (isset($existingTranslationMap[$storeId])) {
+                $existingTranslation = $existingTranslationMap[$storeId];
+                // Only update if value has changed
+                if ($existingTranslation->getTitle() !== $newValue) {
+                    $existingTranslation->setTitle($newValue);
+                    $this->nodeTranslationRepository->save($existingTranslation);
+                }
+                // Remove from map as it's been processed
+                unset($existingTranslationMap[$storeId]);
+            } else {
+                // Create new translation
+                $nodeTranslation = $this->nodeTranslationFactory->create();
+                $nodeTranslation->setNodeId($nodeId);
+                $nodeTranslation->setStoreId($storeId);
+                $nodeTranslation->setTitle($newValue);
+                $this->nodeTranslationRepository->save($nodeTranslation);
+            }
+        }
+
+        // Delete translations that no longer exist
+        foreach ($existingTranslationMap as $translation) {
+            $this->nodeTranslationRepository->delete($translation);
+        }
+
+        return $result;
+    }
+}

--- a/Plugin/Model/Menu/Node/AfterSave.php
+++ b/Plugin/Model/Menu/Node/AfterSave.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Snowdog\Menu\Plugin\Model\Menu\Node;
 
 use Snowdog\Menu\Api\NodeTranslationRepositoryInterface;
-use Snowdog\Menu\Api\Data\NodeTranslationInterface;
 use Snowdog\Menu\Api\Data\NodeTranslationInterfaceFactory;
 use Snowdog\Menu\Model\Menu\Node;
 

--- a/Service/Menu/SaveRequestProcessor.php
+++ b/Service/Menu/SaveRequestProcessor.php
@@ -184,6 +184,11 @@ class SaveRequestProcessor
             $nodeObject->setTarget($nodeData['target']);
         }
 
+        // Handle translations
+        if (isset($nodeData['translations']) && is_array($nodeData['translations'])) {
+            $nodeObject->setData('translations', $nodeData['translations']);
+        }
+
         $nodeTemplate = null;
         if (isset($nodeData['node_template']) && $nodeData['type'] != $nodeData['node_template']) {
             $nodeTemplate = $nodeData['node_template'];

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "snowdog/module-menu",
+  "name": "magebitcom/snowdog-module-menu",
   "description": "Provides powerful menu editor to replace category based menus in Magento 2",
   "license": "MIT",
   "type": "magento2-module",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "magebitcom/snowdog-module-menu",
+  "name": "snowdog/module-menu",
   "description": "Provides powerful menu editor to replace category based menus in Magento 2",
   "license": "MIT",
   "type": "magento2-module",

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -60,4 +60,27 @@
             <column name="node_id"/>
         </index>
     </table>
+    <table name="snowmenu_node_translation" resource="default" engine="innodb" comment="Menu Node Translations">
+        <column xsi:type="int" name="translation_id" padding="10" unsigned="true" nullable="false" identity="true" comment="Translation ID"/>
+        <column xsi:type="int" name="node_id" padding="10" unsigned="true" nullable="false" identity="false" comment="Node ID"/>
+        <column xsi:type="smallint" name="store_id" padding="5" unsigned="true" nullable="false" identity="false" comment="Store ID"/>
+        <column xsi:type="text" name="title" nullable="true" comment="Translated Title"/>
+        <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Creation Time"/>
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP" comment="Update Time"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="translation_id"/>
+        </constraint>
+        <constraint xsi:type="foreign" referenceId="SNOWMENU_NODE_TRANSLATION_NODE_ID_SNOWMENU_NODE_NODE_ID" table="snowmenu_node_translation" column="node_id" referenceTable="snowmenu_node" referenceColumn="node_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="SNOWMENU_NODE_TRANSLATION_STORE_ID_STORE_STORE_ID" table="snowmenu_node_translation" column="store_id" referenceTable="store" referenceColumn="store_id" onDelete="CASCADE"/>
+        <constraint xsi:type="unique" referenceId="SNOWMENU_NODE_TRANSLATION_NODE_ID_STORE_ID">
+            <column name="node_id"/>
+            <column name="store_id"/>
+        </constraint>
+        <index referenceId="SNOWMENU_NODE_TRANSLATION_NODE_ID" indexType="btree">
+            <column name="node_id"/>
+        </index>
+        <index referenceId="SNOWMENU_NODE_TRANSLATION_STORE_ID" indexType="btree">
+            <column name="store_id"/>
+        </index>
+    </table>
 </schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,6 +7,8 @@
     <preference for="Snowdog\Menu\Api\Data\MenuSearchResultsInterface" type="Magento\Framework\Api\SearchResults"/>
     <preference for="Snowdog\Menu\Api\Data\MenuInterface" type="Snowdog\Menu\Model\Menu"/>
     <preference for="Snowdog\Menu\Api\Data\NodeInterface" type="Snowdog\Menu\Model\Menu\Node"/>
+    <preference for="Snowdog\Menu\Api\Data\NodeTranslationInterface" type="Snowdog\Menu\Model\NodeTranslation"/>
+    <preference for="Snowdog\Menu\Api\NodeTranslationRepositoryInterface" type="Snowdog\Menu\Model\NodeTranslationRepository"/>
 
     <type name="Snowdog\Menu\Model\NodeTypeProvider">
         <arguments>
@@ -73,5 +75,10 @@
         <arguments>
             <argument name="validator" xsi:type="object">Snowdog\Menu\Model\ImportExport\Processor\Import\Node\Validator\Proxy</argument>
         </arguments>
+    </type>
+
+    <type name="Snowdog\Menu\Model\Menu\Node">
+        <plugin name="snowdog_menu_node_save_translations"
+                type="Snowdog\Menu\Plugin\Model\Menu\Node\AfterSave"/>
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -81,4 +81,20 @@
         <plugin name="snowdog_menu_node_save_translations"
                 type="Snowdog\Menu\Plugin\Model\Menu\Node\AfterSave"/>
     </type>
+
+    <type name="Snowdog\Menu\Model\ImportExport\Processor\Import\Node">
+        <arguments>
+            <argument name="translationProcessor" xsi:type="object">
+                Snowdog\Menu\Model\ImportExport\Processor\Import\Node\TranslationProcessor
+            </argument>
+        </arguments>
+    </type>
+
+    <virtualType name="Snowdog\Menu\Model\ResourceModel\NodeTranslation\Grid\Collection"
+                 type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
+        <arguments>
+            <argument name="mainTable" xsi:type="string">snowmenu_node_translation</argument>
+            <argument name="resourceModel" xsi:type="string">Snowdog\Menu\Model\ResourceModel\NodeTranslation</argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/view/adminhtml/templates/menu/nodes.phtml
+++ b/view/adminhtml/templates/menu/nodes.phtml
@@ -45,6 +45,7 @@ $vueComponents = $block->getVueComponents();
                         "imageUploadFileId": "<?= $block->getImageUploadFileId() ?>",
                         "lazyMinItemsCount": "1000",
                         "customerGroups"   : <?= json_encode($block->getCustomerGroups()) ?>,
+                        "storeViews"       : <?= json_encode($block->getStoreViews()) ?>,
                         "translation": {
                             "nodes"          : "<?= __('Nodes') ?>",
                             "click"          : "<?= __('Click') ?>",
@@ -76,7 +77,12 @@ $vueComponents = $block->getVueComponents();
                             "imageHeight"   : "<?= __('Image Height') ?>",
                             "selectedItemId" : "<?= __('Selected Item Id') ?>",
                             "customerGroups" : "<?= __('Customer Groups') ?>",
-                            "customerGroupsDescription" : "<?= __('If no customer group is selected, the node will be visible to all customers.') ?>"
+                            "customerGroupsDescription" : "<?= __('If no customer group is selected, the node will be visible to all customers.') ?>",
+                            "store"          : "<?= __('Store View') ?>",
+                            "translation"    : "<?= __('Translation') ?>",
+                            "actions"        : "<?= __('Actions') ?>",
+                            "remove"         : "<?= __('Remove') ?>",
+                            "addTranslation" : "<?= __('Add Translation') ?>"
                         }
                     }
                 }

--- a/view/adminhtml/templates/menu/nodes.phtml
+++ b/view/adminhtml/templates/menu/nodes.phtml
@@ -82,7 +82,7 @@ $vueComponents = $block->getVueComponents();
                             "translation"    : "<?= __('Translation') ?>",
                             "actions"        : "<?= __('Actions') ?>",
                             "remove"         : "<?= __('Remove') ?>",
-                            "addTranslation" : "<?= __('Add Translation') ?>"
+                            "addTranslation" : "<?= __('Add Translation') ?>",
                             "hideIfEmpty"    : "<?= __("Hide node if empty") ?>",
                             "hideIfEmptyDescription" : "<?= __("(e.g. no product in categories)") ?>"
                         }

--- a/view/adminhtml/web/vue/menu-type.vue
+++ b/view/adminhtml/web/vue/menu-type.vue
@@ -108,6 +108,67 @@
         </template>
 
         <h2>
+          {{ translationsLabel }}
+        </h2>
+
+        <div class="admin__field field field-translations" style="margin-left: 0;">
+            <table class="admin__table-secondary">
+                <thead>
+                    <tr>
+                        <th class="col-store">{{ config.translation.store }}</th>
+                        <th class="col-translation">{{ config.translation.translation }}</th>
+                        <th class="col-actions">{{ config.translation.actions }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="(translation, index) in translations" :key="index">
+                        <td class="col-store">
+                            <v-select
+                                :input-id="'store_' + index"
+                                v-model="translation.store_id"
+                                :options="config.storeViews"
+                                :reduce="store => store.value"
+                                :get-option-label="option => option.label || translation.label"
+                                :clearable="false"
+                                @input="updateTranslation(index)"
+                            />
+                        </td>
+                        <td class="col-translation">
+                            <input
+                                type="text"
+                                class="admin__control-text"
+                                v-model="translation.value"
+                                @input="updateTranslation(index)"
+                            />
+                        </td>
+                        <td class="col-actions">
+                            <button
+                                type="button"
+                                class="action-delete"
+                                @click="removeTranslation(index)"
+                            >
+                                <span>{{ config.translation.remove }}</span>
+                            </button>
+                        </td>
+                    </tr>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="3">
+                            <button
+                                type="button"
+                                class="action-secondary"
+                                @click="addTranslation"
+                            >
+                                <span>{{ config.translation.addTranslation }}</span>
+                            </button>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+
+        <h2>
             {{ templatesLabel }}
         </h2>
 
@@ -150,14 +211,22 @@
             data() {
                 return {
                     draft: {},
+                    translations: [],
                     isNodeActiveLabel: $t('Enabled'),
                     additionalLabel: $t('Additional type options'),
                     noTemplatesMessage: $t('There is no custom defined templates defined in theme for this node type'),
                     templatesLabel: $t('Templates'),
+                    translationsLabel: $t('Translations'),
                     templateList: {
                       'node': 'snowMenuNodeCustomTemplates',
                       'submenu': 'snowMenuSubmenuCustomTemplates',
                     }
+                }
+            },
+            created() {
+                // Initialize translations from item data if they exist
+                if (this.item.translations) {
+                    this.translations = this.item.translations;
                 }
             },
             computed: {
@@ -215,6 +284,31 @@
                         return this.config.nodeTypes[option];
                     }
                     return option;
+                },
+                updateTranslation(index) {
+                    // Sync translations back to item
+                    this.item.translations = [...this.translations];
+                },
+                addTranslation() {
+                    this.translations.push({
+                        store_id: '',
+                        value: ''
+                    });
+                    this.updateTranslation();
+                },
+                removeTranslation(index) {
+                    this.translations.splice(index, 1);
+                    this.updateTranslation();
+                }
+            },
+            watch: {
+                'item.translations': {
+                    handler(newVal) {
+                        if (newVal && Array.isArray(newVal)) {
+                            this.translations = [...newVal];
+                        }
+                    },
+                    immediate: true
                 }
             },
             template: template


### PR DESCRIPTION
Fixes review issues raised in #360:

  - Use existing `getStoreViews()` instead of duplicate store view lookup in `Nodes.php`
  - Wrap `nodeTranslationRepository->save()` in try-catch with logging in `TranslationProcessor`
  - Remove unused `getIdByCode()` method and `StoreManagerInterface` dependency from `Store`
  - Add missing constants and method declarations to `NodeTranslationInterface`
  - Remove unused `getValue()` / `setValue()` from `NodeTranslation`
  - Remove unused `NodeTranslationInterface` import in `AfterSave`