### PR TITLE
Add `int` return type to `NodesValidatorCommand::execute()`

### DIFF
--- a/Console/Command/NodesValidatorCommand.php
+++ b/Console/Command/NodesValidatorCommand.php
@@ -72,7 +72,7 @@ class NodesValidatorCommand extends Command
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->setAreaCode();
         $invalidNodeIds = [];


### PR DESCRIPTION
Symfony Console's `Command::execute()` declares an `int` return type, but the override in `NodesValidatorCommand` lacked the type hint, causing a signature mismatch.

## Change

- `Console/Command/NodesValidatorCommand.php`: add `: int` return type to `execute()`

```diff
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
```

The method body already returns `0` in all paths; no logic changes were needed.