### PR TITLE
Fix duplicated menu with changed identifier throws an error if same submenu template does not exist

### DIFF
--- a/Block/Menu.php
+++ b/Block/Menu.php
@@ -445,9 +445,15 @@ class Menu extends Template implements DataObject\IdentityInterface
     {
         $block = clone $this;
         $submenuTemplate = $parentNode->getSubmenuTemplate();
-        $submenuTemplate = $submenuTemplate
-            ? 'Snowdog_Menu::' . $this->getMenu()->getIdentifier() . "/menu/custom/sub_menu/{$submenuTemplate}.phtml"
-            : $this->submenuTemplate;
+
+        if ($submenuTemplate) {
+            $customSubmenuTemplate = 'Snowdog_Menu::' . $this->getMenu()->getIdentifier() . "/menu/custom/sub_menu/{$submenuTemplate}.phtml";
+            $submenuTemplate = $this->templateResolver->isValidTemplate($block, $customSubmenuTemplate)
+                ? $customSubmenuTemplate
+                : $this->submenuTemplate;
+        } else {
+            $submenuTemplate = $this->submenuTemplate;
+        }
 
         $block->setSubmenuNodes($nodes)
             ->setParentNode($parentNode)

--- a/Model/TemplateResolver.php
+++ b/Model/TemplateResolver.php
@@ -116,6 +116,16 @@ class TemplateResolver
     }
 
     /**
+     * @param Template $block
+     * @param string $template
+     * @return bool
+     */
+    public function isValidTemplate($block, $template)
+    {
+        return (bool) $this->validator->isValid($block->getTemplateFile($template));
+    }
+
+    /**
      * @param string $nodeType
      * @param string $defaultTemplateLabel
      * @return array


### PR DESCRIPTION
## Description

Fixes an issue where a duplicated menu can break the frontend when its configured submenu template does not exist for the new menu identifier.

This issue was originally reported in [#379](https://github.com/SnowdogApps/magento2-menu/issues/379) and later reproduced with an `Invalid template file` exception in [#391](https://github.com/SnowdogApps/magento2-menu/issues/391).

### Previous Approach

The initial fix was proposed in [PR #393](https://github.com/SnowdogApps/magento2-menu/pull/393).

The previous implementation added Hyva-specific template validation to `Block/Menu.php`. Since `Block/Menu.php` is shared across themes and should remain theme-agnostic, this approach was not suitable.

### Changes

- Added an `isValidTemplate()` method to `TemplateResolver.php` to validate whether a template is available and valid within the current theme/module layout framework.
- Updated `Menu.php` to validate the custom submenu template before using it.
- If the custom submenu template is not valid for the current menu identifier, the menu falls back to the default submenu template.
- Keeps `Block/Menu.php` theme-agnostic without introducing Hyva-specific logic.

### How the Fix Solves It

When a menu is duplicated and its identifier is changed, the copied submenu template may no longer exist for the new identifier.

The custom submenu template is now validated before it is assigned:

1. The custom submenu template path is constructed using the current menu identifier.
2. `isValidTemplate()` checks whether the template is available and valid.
3. If the template is valid, it is used as before.
4. If the template is not valid, the default submenu template is used instead.

This prevents an invalid submenu template from breaking the frontend while preserving the existing submenu template configuration.

## How to Test

1. Create a new menu with the identifier `hyva-topmenu-desktop`.
2. Add categories and subcategories to the menu and create a parent/child hierarchy.
3. Assign the `3-level` submenu template, ensuring that it is specific to `hyva-topmenu-desktop`.
4. Duplicate the menu and change its identifier to `hyva-topmenu-mobile`.
5. Enable the duplicated menu.
6. Clear the cache and refresh the frontend.

### Expected Result

The frontend should render the menu using the default submenu template instead of throwing an `Invalid template file` exception.

### Related Issues / PRs

- Original issue: [#379](https://github.com/SnowdogApps/magento2-menu/issues/379)
- Referenced issue: [#391](https://github.com/SnowdogApps/magento2-menu/issues/391)
- Previous proposed fix: [#393](https://github.com/SnowdogApps/magento2-menu/pull/393)